### PR TITLE
[SETTING] 공통 클래스 & 예외 핸들링 클래스 세팅 - #3

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/common/ApiResponseUtil.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/ApiResponseUtil.java
@@ -1,0 +1,22 @@
+package org.dateroad.common;
+
+import org.dateroad.code.FailureCode;
+import org.dateroad.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+
+public interface ApiResponseUtil {
+    public static ResponseEntity<SuccessResponse<?>> success(SuccessCode successCode) {
+        return ResponseEntity.status(successCode.getHttpStatus())
+                .body(SuccessResponse.of(successCode));
+    }
+
+    public static <T> ResponseEntity<SuccessResponse<T>> success(SuccessCode successCode, T data) {
+        return ResponseEntity.status(successCode.getHttpStatus())
+                .body(SuccessResponse.of(successCode, data));
+    }
+
+    public static ResponseEntity<FailureResponse> failure(FailureCode failureCode) {
+        return ResponseEntity.status(failureCode.getHttpStatus())
+                .body(FailureResponse.of(failureCode));
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/common/FailureResponse.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/FailureResponse.java
@@ -1,0 +1,19 @@
+package org.dateroad.common;
+
+import lombok.Builder;
+import org.dateroad.code.FailureCode;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record FailureResponse(
+        int status,
+        String message
+) {
+    public static FailureResponse of(FailureCode failureCode) {
+        return FailureResponse.builder()
+                .status(failureCode.getHttpStatus().value())
+                .message(failureCode.getMessage())
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/common/FailureResponse.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/FailureResponse.java
@@ -8,11 +8,13 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public record FailureResponse(
         int status,
+        String code,
         String message
 ) {
     public static FailureResponse of(FailureCode failureCode) {
         return FailureResponse.builder()
                 .status(failureCode.getHttpStatus().value())
+                .code(failureCode.getCode())
                 .message(failureCode.getMessage())
                 .build();
     }

--- a/dateroad-api/src/main/java/org/dateroad/common/GlobalExceptionHandler.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package org.dateroad.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.dateroad.code.FailureCode;
+import org.dateroad.exception.DateRoadException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<FailureResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        log.error(">>> handle: MethodArgumentNotValidException ", e);
+        return ApiResponseUtil.failure(FailureCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<FailureResponse> handleBindException(final BindException e) {
+        log.error(">>> handle: BindException ", e);
+        return ApiResponseUtil.failure(FailureCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<FailureResponse> handleMethodArgumentTypeMismatchException(final MethodArgumentTypeMismatchException e) {
+        log.error(">>> handle: MethodArgumentTypeMismatchException ", e);
+        return ApiResponseUtil.failure(FailureCode.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<FailureResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
+        log.error(">>> handle: HttpRequestMethodNotSupportedException ", e);
+        return ApiResponseUtil.failure(FailureCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(DateRoadException.class)
+    protected ResponseEntity<FailureResponse> handleBusinessException(final DateRoadException e) {
+        log.error(">>> handle: DateRoadException ", e);
+        return ApiResponseUtil.failure(e.getFailureCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<FailureResponse> handleException(final Exception e) {
+        log.error(">>> handle: Exception ", e);
+        return ApiResponseUtil.failure(FailureCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/common/SuccessResponse.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/SuccessResponse.java
@@ -10,6 +10,7 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public record SuccessResponse<T>(
         int status,
+        String code,
         String message,
         @JsonInclude(value = NON_NULL)
         T data
@@ -17,6 +18,7 @@ public record SuccessResponse<T>(
     public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
         return SuccessResponse.<T>builder()
                 .status(successCode.getHttpStatus().value())
+                .code(successCode.getCode())
                 .message(successCode.getMessage())
                 .data(data)
                 .build();
@@ -25,6 +27,7 @@ public record SuccessResponse<T>(
     public static SuccessResponse<?> of(SuccessCode successCode) {
         return SuccessResponse.builder()
                 .status(successCode.getHttpStatus().value())
+                .code(successCode.getCode())
                 .message(successCode.getMessage())
                 .build();
     }

--- a/dateroad-api/src/main/java/org/dateroad/common/SuccessResponse.java
+++ b/dateroad-api/src/main/java/org/dateroad/common/SuccessResponse.java
@@ -1,0 +1,31 @@
+package org.dateroad.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import org.dateroad.code.SuccessCode;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        @JsonInclude(value = NON_NULL)
+        T data
+) {
+    public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
+        return SuccessResponse.<T>builder()
+                .status(successCode.getHttpStatus().value())
+                .message(successCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static SuccessResponse<?> of(SuccessCode successCode) {
+        return SuccessResponse.builder()
+                .status(successCode.getHttpStatus().value())
+                .message(successCode.getMessage())
+                .build();
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -1,0 +1,49 @@
+package org.dateroad.code;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum FailureCode {
+    /**
+     * 400 Bad Request
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
+
+    /**
+     * 401 Unauthorized
+     */
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "e4010", "리소스 접근 권한이 없습니다."),
+
+    /**
+     * 403 Forbidden
+     */
+    FORBIDDEN(HttpStatus.FORBIDDEN, "e4030", "리소스 접근 권한이 없습니다."),
+
+    /**
+     * 404 Not Found
+     */
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
+
+    /**
+     * 405 Method Not Allowed
+     */
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "e4050", "잘못된 HTTP method 요청입니다."),
+
+    /**
+     * 409 Conflict
+     */
+    CONFLICT(HttpStatus.CONFLICT, "e4090", "이미 존재하는 리소스입니다."),
+
+    /**
+     * 500 Internal Server Error
+     */
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5000", "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/dateroad-common/src/main/java/org/dateroad/code/SuccessCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/SuccessCode.java
@@ -1,0 +1,18 @@
+package org.dateroad.code;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+
+    OK(HttpStatus.OK, "s2000", "요청이 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "s2010", "요청이 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/dateroad-common/src/main/java/org/dateroad/exception/ConflictException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/ConflictException.java
@@ -1,0 +1,13 @@
+package org.dateroad.exception;
+
+import org.dateroad.code.FailureCode;
+
+public class ConflictException extends DateRoadException {
+    public ConflictException() {
+        super(FailureCode.CONFLICT);
+    }
+
+    public ConflictException(FailureCode failureCode) {
+        super(failureCode);
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/exception/DateRoadException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/DateRoadException.java
@@ -1,0 +1,14 @@
+package org.dateroad.exception;
+
+import lombok.Getter;
+import org.dateroad.code.FailureCode;
+
+@Getter
+public class DateRoadException extends RuntimeException {
+    private final FailureCode failureCode;
+
+    public DateRoadException(FailureCode failureCode) {
+        super(failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/exception/EntityNotFoundException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/EntityNotFoundException.java
@@ -1,0 +1,13 @@
+package org.dateroad.exception;
+
+import org.dateroad.code.FailureCode;
+
+public class EntityNotFoundException extends DateRoadException {
+    public EntityNotFoundException() {
+        super(FailureCode.ENTITY_NOT_FOUND);
+    }
+
+    public EntityNotFoundException(FailureCode failureCode) {
+        super(failureCode);
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/exception/InvalidValueException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/InvalidValueException.java
@@ -1,0 +1,13 @@
+package org.dateroad.exception;
+
+import org.dateroad.code.FailureCode;
+
+public class InvalidValueException extends DateRoadException {
+    public InvalidValueException() {
+        super(FailureCode.BAD_REQUEST);
+    }
+
+    public InvalidValueException(FailureCode failureCode) {
+        super(failureCode);
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/exception/UnauthorizedException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/UnauthorizedException.java
@@ -1,0 +1,13 @@
+package org.dateroad.exception;
+
+import org.dateroad.code.FailureCode;
+
+public class UnauthorizedException extends DateRoadException {
+    public UnauthorizedException() {
+        super(FailureCode.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(FailureCode failureCode) {
+        super(failureCode);
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/3

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- API 성공, 실패 응답 클래스를 나누어 SuccessResponse, FailureResponse를 구현하였습니다. 
- 공통 응답 클래스를 활용하여 최종적으로 ResponseEntity를 API 응답으로 반환하는 역할을 가진 ApiResponseUtil 인터페이스를 구현하였습니다.
- 예외 처리를 위해 RuntimeException을 상속 받은 DateRoadException 클래스를 구현하였습니다.
- 각 HTTP 예외 Status를 명확하게 구분하여 처리하기 위해 DateRoadException을 상속 받은 CustomException 클래스들을 구현하였습니다.
- 동일한 HTTP 예외 Status에서 다양하게 발생할 수 있는 예외 상황들을 메시지와 코드로 관리하기 위해 FailureCode Enum 클래스를 구현하였습니다.
- 성공 코드를 관리하는 SuccessCode Enum 클래스를 구현하였습니다.
- 전역적으로 스프링 부트 내부에서 발생하는 예외를 핸들링 하기 위해 @ControllerAdvice 어노테이션과 @ExceptionHandler 어노테이션을 활용해 GlobalExceptionHandler 클래스를 구현하였습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 성공과 실패 응답 클래스를 분리해두면 가독성이 좋아지기도 하고, 실패 응답 클래스에서는 데이터를 따로 가지고 있지 않다는 차이점에서 공통 응답 객체를 분리해서 구현하였습니다.

## 📟 관련 이슈
- Resolved: #3 