### PR TITLE
[FEAT] UserId Argument Resolver 구현-  #15

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserId.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserId.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface userId {
+public @interface UserId {
 }

--- a/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
@@ -16,9 +16,9 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
         //UserId 어노테이션을 parameter가 가지고 있는지 확인
         boolean isParamHasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
 
-        //parameter의 타입이 long인지 확인 -> 필터에서 이미 long인지 타입이 확인되는데 필요할까? 의문이 생김
-        boolean isParamlongType = long.class.equals(parameter.getParameterType());
-        return isParamHasUserIdAnnotation && isParamlongType;
+        //parameter의 타입이 Long인지 확인
+        boolean isParamLongType = Long.class.equals(parameter.getParameterType());
+        return isParamHasUserIdAnnotation && isParamLongType;
     }
 
     @Override

--- a/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
@@ -1,0 +1,29 @@
+package org.dateroad.auth.argumentresolve;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        //UserId 어노테이션을 parameter가 가지고 있는지 확인
+        boolean isParamHasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);
+
+        //parameter의 타입이 long인지 확인 -> 필터에서 이미 long인지 타입이 확인되는데 필요할까? 의문이 생김
+        boolean isParamlongType = long.class.equals(parameter.getParameterType());
+
+        return isParamHasUserIdAnnotation && isParamlongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/UserIdArgumentResolver.java
@@ -2,11 +2,13 @@ package org.dateroad.auth.argumentresolve;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -16,7 +18,6 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
         //parameter의 타입이 long인지 확인 -> 필터에서 이미 long인지 타입이 확인되는데 필요할까? 의문이 생김
         boolean isParamlongType = long.class.equals(parameter.getParameterType());
-
         return isParamHasUserIdAnnotation && isParamlongType;
     }
 

--- a/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/userId.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/argumentresolve/userId.java
@@ -1,0 +1,11 @@
+package org.dateroad.auth.argumentresolve;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface userId {
+}

--- a/dateroad-api/src/main/java/org/dateroad/auth/config/WebConfig.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/config/WebConfig.java
@@ -1,0 +1,20 @@
+package org.dateroad.auth.config;
+
+import lombok.RequiredArgsConstructor;
+import org.dateroad.auth.argumentresolve.UserIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
Controller단에서 중복되는 로직의 반복적 구현을 피하기 위해, ArgumnetResolver와 커스텀 어노테이션을 사용해서 구현했습니다.

Argument Resolver 를 사용하면 컨트롤러 메소드의 파라미터 중 특정 조건에 맞는 파라미터가 있다면, 요청에 들어온 값을 원하는 객체를 만들어 바인딩해줄 수 있습니다.

### 1. UserId 어노테이션 
```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
public @interface UserId {
}
```
- @Target : 파라미터에 UserId 어노테이션을 사용할 수 있습니다.
- @Retention(RetentionPolicy.RUNTIME) :  런타임까지 애노테이션 정보가 남아있다는 뜻입니다.

### 2. UserIdArgumentResolver
```java
    @Override
    public boolean supportsParameter(MethodParameter parameter) {

        //UserId 어노테이션을 parameter가 가지고 있는지 확인
        boolean isParamHasUserIdAnnotation = parameter.hasParameterAnnotation(UserId.class);

        //parameter의 타입이 long인지 확인 -> 필터에서 이미 long인지 타입이 확인되는데 필요할까? 의문이 생김
        boolean isParamlongType = long.class.equals(parameter.getParameterType());
        return isParamHasUserIdAnnotation && isParamlongType;
    }
```
- 우선 supportsParameter에서는 두가지를 확인합니다.
  - userId 어노테이션을 parameter가 가지고 있는지 확인합니다.
  - parameter의 타입이 long인 지 확인합니다. (이 부분은 아래 참고사항에서 의견을 물어볼게요!)
  - 두가지 모두 true여야 실행됩니다.


```java
    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
        return SecurityContextHolder.getContext()
                .getAuthentication()
                .getPrincipal();
    }
}
```
- SecurityContextHolder에 있는 userId를 가져옵니다.

### 3. WebConfig
```java
@RequiredArgsConstructor
@Configuration
public class WebConfig implements WebMvcConfigurer {
    private final UserIdArgumentResolver userIdArgumentResolver;

    @Override
    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
        resolvers.add(userIdArgumentResolver);
    }
}
```
- 마지막으로 WebConfig에 UserIdArgumentResolver를 등록해줍니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
위 2번 UserIdArgumentResolver에서 long 타입 체크를 하는 것이 중복체크일수도 있다는 생각이 들어서 의견 구합니다.
이미 Security Filter에서 long 타입인지를 확인했을텐데, 여기서 또 해줘야되는게 궁금합니다.
```java
//parameter의 타입이 long인지 확인 -> 필터에서 이미 long인지 타입이 확인되는데 필요할까? 의문이 생김
        boolean isParamlongType = long.class.equals(parameter.getParameterType());
        return isParamHasUserIdAnnotation && isParamlongType;
```

## 👉 사용법
- 예시 코드
```java
    @PatchMapping("/signout")
    @Override
    public ResponseEntity<BaseResponse<?>> signOut(@UserId final Long userId) {
    }
```
위와 같이 파라미터에 UserId 어노테이션을 사용하면 됩니다.

- 여기서도 궁금한게 userId가 long으로 나오는 것이 이미 필터와 UserIdArgumnet에서 인증이 되었으니,  Long말고 long을 사용하는 것이 어떤지도 의견 구합니다


## 📟 관련 이슈
- Resolved: #15 