### PR TITLE
[FEAT] S3 기본 세팅 - #13

### DIFF
--- a/dateroad-external/build.gradle
+++ b/dateroad-external/build.gradle
@@ -1,5 +1,11 @@
 dependencies {
     implementation project(path: ':dateroad-common')
+
+    // AWS sdk
+    implementation("software.amazon.awssdk:bom:2.21.0")
+    implementation("software.amazon.awssdk:s3:2.21.0")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 bootJar.enabled = false

--- a/dateroad-external/src/main/java/org/dateroad/s3/AWSConfig.java
+++ b/dateroad-external/src/main/java/org/dateroad/s3/AWSConfig.java
@@ -1,0 +1,46 @@
+package org.dateroad.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AWSConfig {
+
+    private static final String AWS_ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String AWS_SECRET_ACCESS_KEY = "aws.secretAccessKey";
+    private final String accessKey;
+    private final String secretKey;
+    private final String regionString;
+
+    public AWSConfig(@Value("${aws-property.access-key}") final String accessKey,
+                     @Value("${aws-property.secret-key}") final String secretKey,
+                     @Value("${aws-property.aws-region}") final String regionString) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.regionString = regionString;
+    }
+
+    @Bean
+    public SystemPropertyCredentialsProvider systemPropertyCredentialsProvider() {
+        System.setProperty(AWS_ACCESS_KEY_ID, accessKey);
+        System.setProperty(AWS_SECRET_ACCESS_KEY, secretKey);
+        return SystemPropertyCredentialsProvider.create();
+    }
+
+    @Bean
+    public Region getRegion() {
+        return Region.of(regionString);
+    }
+
+    @Bean
+    public S3Client getS3Client() {
+        return S3Client.builder()
+                .region(getRegion())
+                .credentialsProvider(systemPropertyCredentialsProvider())
+                .build();
+    }
+}

--- a/dateroad-external/src/main/java/org/dateroad/s3/S3Service.java
+++ b/dateroad-external/src/main/java/org/dateroad/s3/S3Service.java
@@ -1,0 +1,78 @@
+package org.dateroad.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class S3Service {
+
+    private final String bucketName;
+    private final AWSConfig awsConfig;
+    private static final List<String> IMAGE_EXTENSIONS = Arrays.asList("image/jpeg", "image/png", "image/jpg", "image/webp");
+
+
+    public S3Service(@Value("${aws-property.s3-bucket-name}") final String bucketName, AWSConfig awsConfig) {
+        this.bucketName = bucketName;
+        this.awsConfig = awsConfig;
+    }
+
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        final String key = directoryPath + generateImageFileName();
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        validateExtension(image);
+        validateFileSize(image);
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(image.getContentType())
+                .contentDisposition("inline")
+                .build();
+
+        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
+        s3Client.putObject(request, requestBody);
+        return key;
+    }
+
+    public void deleteImage(String key) throws IOException {
+        final S3Client s3Client = awsConfig.getS3Client();
+
+        s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
+                builder.bucket(bucketName)
+                        .key(key)
+                        .build()
+        );
+    }
+
+    private String generateImageFileName() {
+        return UUID.randomUUID() + ".jpg";
+    }
+
+
+    private void validateExtension(MultipartFile image) {
+        String contentType = image.getContentType();
+        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+            throw new RuntimeException("이미지 확장자는 jpg, png, webp만 가능합니다.");
+        }
+    }
+
+    private static final Long MAX_FILE_SIZE = 5 * 1024 * 1024L;
+
+    private void validateFileSize(MultipartFile image) {
+        if (image.getSize() > MAX_FILE_SIZE) {
+            throw new RuntimeException("이미지 사이즈는 5MB를 넘을 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#13

👷 **작업한 내용**
AWS의 S3를 사용하기 위해 기본 세팅해놨습니다.
테스트하기 위해서 S3Service를 임의로 작성해놨으니 필요한대로 리팩토링하셔서 쓰시면 될 것 같습니다. (사실 세팅만 하느라 Exception도 저희 컨벤션 Exception 안썼으니까.. 참고해주세요 죄송합니다....)

```
    @PostMapping("/upload")
    public ResponseEntity<String> uploadFile(
            @ModelAttribute CourseDto courseDto
    ) {
        try {
            String url = s3Service.uploadImage(BLOG_S3_UPLOAD_FOLER, courseDto.image());
            return ResponseEntity.ok(url);
        } catch (RuntimeException | IOException e) {
            throw new ConflictException(FailureCode.INTERNAL_SERVER_ERROR);
        }
    }
```

<img width="635" alt="스크린샷 2024-07-08 오전 1 04 06" src="https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/102401928/4fa6bbdc-fc34-412b-91be-295a91c3dc97">

해당 Api를 만들어 다음 사진과 같은 형식으로 Api 요청을 보내 테스트 해본 결과, S3 버킷에 지정된 폴더에 잘 저장되어 기능하는 것을 확인했습니다.

<img width="551" alt="스크린샷 2024-07-08 오전 1 05 20" src="https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/102401928/69b13677-1750-4139-8b46-55fdb75735e4">

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
꼭 Service는 리팩터링 하세요...

## 📟 관련 이슈
- Resolved: #13