### PR TITLE
[FEAT] 데이트 코스 전체 조회 API 구현 

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -13,8 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/")
-///api/v1/courses : url change
+@RequestMapping("/api/v1/courses")
 @RequiredArgsConstructor
 public class CourseController {
     private final CourseService courseService;

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -1,0 +1,31 @@
+package org.dateroad.course.api;
+
+
+import lombok.RequiredArgsConstructor;
+import org.dateroad.course.dto.request.CourseGetAllReq;
+import org.dateroad.course.dto.response.CourseGetAllRes;
+import org.dateroad.course.service.CourseService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+///api/v1/courses : url change
+@RequiredArgsConstructor
+public class CourseController {
+    private final CourseService courseService;
+
+    @GetMapping
+    public ResponseEntity<CourseGetAllRes> getAllCourse(
+            @ModelAttribute CourseGetAllReq courseGetAllReq
+    ) {
+        CourseGetAllRes courseAll = courseService.getAllCourses(courseGetAllReq);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(courseAll);
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseGetAllReq.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseGetAllReq.java
@@ -1,0 +1,8 @@
+package org.dateroad.course.dto.request;
+
+public record CourseGetAllReq(
+        String country,
+        String city,
+        Integer cost
+) {
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/response/CourseGetAllRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/response/CourseGetAllRes.java
@@ -1,0 +1,22 @@
+package org.dateroad.course.dto.response;
+
+import java.util.List;
+
+public record CourseGetAllRes(
+        List<CourseDtoRes> courses
+) {
+    public record CourseDtoRes(
+            Long courseId,
+            String thumbnail,
+            String city,
+            String title,
+            int like,
+            int cost,
+            int duration
+    ) {
+    }
+
+    public static CourseGetAllRes of(List<CourseDtoRes> courses) {
+        return new CourseGetAllRes(courses);
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -1,0 +1,48 @@
+package org.dateroad.course.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.dateroad.course.dto.request.CourseGetAllReq;
+import org.dateroad.course.dto.response.CourseGetAllRes;
+import org.dateroad.course.dto.response.CourseGetAllRes.CourseDtoRes;
+import org.dateroad.date.domain.Course;
+import org.dateroad.date.repository.CourseRepository;
+import org.dateroad.image.domain.Image;
+import org.dateroad.image.repository.ImageRepository;
+import org.dateroad.like.repository.LikeRepository;
+import org.dateroad.place.repository.CoursePlaceRepository;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+    private final CourseRepository courseRepository;
+    private final LikeRepository likeRepository;
+    private final ImageRepository imageRepository;
+    private final CoursePlaceRepository coursePlaceRepository;
+
+    public CourseGetAllRes getAllCourses(CourseGetAllReq courseGetAllReq) {
+        Specification<Course> spec = CourseSpecifications.filterByCriteria(courseGetAllReq);
+        List<Course> courses = courseRepository.findAll(spec);
+        return CourseGetAllRes.of(courses.stream().map(this::convertToDto).collect(Collectors.toList()));
+    }
+
+    private CourseDtoRes convertToDto(Course course) {
+        int likeCount = likeRepository.countByCourse(course);
+        Image thumbnailImage = imageRepository.findFirstByCourseOrderBySequenceAsc(course);
+        String thumbnailUrl = thumbnailImage != null ? thumbnailImage.getImageUrl() : null;
+        int duration = coursePlaceRepository.findTotalDurationByCourseId(course.getId());
+
+        return new CourseDtoRes(
+                course.getId(),
+                thumbnailUrl,
+                course.getCity(),
+                course.getTitle(),
+                likeCount,
+                course.getCost(),
+                duration
+        );
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseSpecifications.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseSpecifications.java
@@ -1,0 +1,33 @@
+package org.dateroad.course.service;
+
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+import org.dateroad.course.dto.request.CourseGetAllReq;
+import org.dateroad.date.domain.Course;
+import org.springframework.data.jpa.domain.Specification;
+
+public class CourseSpecifications {
+    public static Specification<Course> filterByCriteria(CourseGetAllReq courseGetAllReq) {
+        String city = courseGetAllReq.city();
+        String country = courseGetAllReq.country();
+        Integer cost = courseGetAllReq.cost();
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (city != null && !city.isEmpty()) {
+                predicates.add(criteriaBuilder.equal(root.get("city"), city));
+            }
+
+            if (country != null && !country.isEmpty()) {
+                predicates.add(criteriaBuilder.equal(root.get("country"), country));
+            }
+
+            if (cost != null) {
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), cost));
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/dateroad-domain/src/main/java/org/dateroad/date/domain/Course.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/domain/Course.java
@@ -12,11 +12,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -1,0 +1,14 @@
+package org.dateroad.date.repository;
+
+import java.util.List;
+import org.dateroad.date.domain.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+// CourseRepository.java
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> , JpaSpecificationExecutor<Course> {
+}
+

--- a/dateroad-domain/src/main/java/org/dateroad/image/domain/Image.java
+++ b/dateroad-domain/src/main/java/org/dateroad/image/domain/Image.java
@@ -13,7 +13,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.dateroad.common.BaseTimeEntity;
 import org.dateroad.date.domain.Course;
 
@@ -35,6 +37,7 @@ public class Image extends BaseTimeEntity {
 
     @Column(name = "image_url")
     @NotNull
+    @Getter
     private String imageUrl;
 
     @Column(name = "sequence")

--- a/dateroad-domain/src/main/java/org/dateroad/image/repository/ImageRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/image/repository/ImageRepository.java
@@ -1,0 +1,12 @@
+package org.dateroad.image.repository;
+
+import java.util.Optional;
+import org.dateroad.date.domain.Course;
+import org.dateroad.image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Image findFirstByCourseOrderBySequenceAsc(Course course);
+}

--- a/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
@@ -1,0 +1,11 @@
+package org.dateroad.like.repository;
+
+import org.dateroad.date.domain.Course;
+import org.dateroad.like.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    int countByCourse(Course course);
+}

--- a/dateroad-domain/src/main/java/org/dateroad/place/repository/CoursePlaceRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/place/repository/CoursePlaceRepository.java
@@ -1,0 +1,15 @@
+package org.dateroad.place.repository;
+
+import java.util.List;
+import org.dateroad.date.domain.Course;
+import org.dateroad.place.domain.CoursePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CoursePlaceRepository extends JpaRepository<CoursePlace,Long> {
+    @Query("SELECT SUM(p.duration) FROM CoursePlace p WHERE p.course.id = :courseId")
+    Integer findTotalDurationByCourseId(@Param("courseId") Long courseId);
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#22

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 코스 전체 조회 API 구현
- CourseController 구현
- CourseService 구현
- CourseRepository구현
- 조건 필터링을 위한 CourseSpecifications 구현 
- 이하 
   - CourseGetAllReq에는 코스 지역 대분류,소분류, 가격  3가지로 입력을 받고있습니다.
   - 이후 CourseSecification에서 각각 값이 들어오지 않았을 경우 null 확인을 통해 각각의 Predicates를 추가하게 됩니다. 
   - 이후 이러한 predicates가 CourseRepository에서 이러한 Predicate값을 넘겨 조건에 따라 필터링해서 값을 찾을 수 있습니다. 
   - https://github.com/TeamDATEROAD/DATEROAD-SERVER/blob/42499e88a4f8fdbc54b77dc62604d34ba3fc1d44/dateroad-api/src/main/java/org/dateroad/course/service/CourseSpecifications.java#L10-L33

### Example 
- cost만 들어갔을 경우 
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/e6a73e2e-440d-4231-84fc-16aac5981b0e)
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/0e98ea1a-4819-4607-aa33-5a157cb67bbc)
- city랑 cost가 들어갔을 경우 
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/48826a11-7a20-40bd-af12-67b1f17d3f6c)
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/6aa78632-4629-4ada-bd9d-c963cd4d4540)
- 아무것도 없을 경우
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/539ac48f-e585-48d8-8296-d1688e4106a0)
![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/40743105/8e3faf3a-4ec5-4681-b073-9d2ddf7cf6b0)


- Image , CoursePlace, Like Repository 구현

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #22 