### PR TITLE
[FEAT] 광고 전체 조회 API 구현

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/advertisment/api/AdvertismentController.java
+++ b/dateroad-api/src/main/java/org/dateroad/advertisment/api/AdvertismentController.java
@@ -1,0 +1,24 @@
+package org.dateroad.advertisment.api;
+
+import lombok.RequiredArgsConstructor;
+import org.dateroad.advertisment.dto.response.AdvGetAllRes;
+import org.dateroad.advertisment.service.AdvertismentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/advertisments")
+public class AdvertismentController {
+    private final AdvertismentService advertismentService;
+
+    @GetMapping
+    public ResponseEntity<AdvGetAllRes> getAllAdvertisments(){
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(advertismentService.getAllAdvertisments());
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/advertisment/dto/response/AdvGetAllRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/advertisment/dto/response/AdvGetAllRes.java
@@ -1,0 +1,23 @@
+package org.dateroad.advertisment.dto.response;
+
+import java.util.List;
+import org.dateroad.advertisement.domain.AdTagType;
+import org.dateroad.advertisement.domain.Advertisment;
+
+public record AdvGetAllRes(
+        List<AdvertismentDtoRes> advertismentDtoResList
+) {
+    public record AdvertismentDtoRes(
+            Long advertismentId,
+            String imageUrl,
+            String title,
+            AdTagType tag
+    ){
+        public static AdvertismentDtoRes of(Advertisment advertisment) {
+            return new AdvertismentDtoRes(advertisment.getId(), advertisment.getTitle(), advertisment.getThumbnail(), advertisment.getTag());
+        }
+    }
+    public static AdvGetAllRes of(List<AdvertismentDtoRes> advertismentDtoResList) {
+        return new AdvGetAllRes(advertismentDtoResList);
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/advertisment/dto/response/AdvGetAllRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/advertisment/dto/response/AdvGetAllRes.java
@@ -9,7 +9,7 @@ public record AdvGetAllRes(
 ) {
     public record AdvertismentDtoRes(
             Long advertismentId,
-            String imageUrl,
+            String thumbnail,
             String title,
             AdTagType tag
     ){

--- a/dateroad-api/src/main/java/org/dateroad/advertisment/service/AdvertismentService.java
+++ b/dateroad-api/src/main/java/org/dateroad/advertisment/service/AdvertismentService.java
@@ -1,0 +1,23 @@
+package org.dateroad.advertisment.service;
+
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.dateroad.advertisement.repository.AdvertismentRepository;
+import org.dateroad.advertisment.dto.response.AdvGetAllRes;
+import org.dateroad.advertisment.dto.response.AdvGetAllRes.AdvertismentDtoRes;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdvertismentService {
+    private final AdvertismentRepository advertismentRepository;
+    public AdvGetAllRes getAllAdvertisments() {
+        Pageable topFive = PageRequest.of(0, 5);
+        return AdvGetAllRes.of(advertismentRepository.findTop5ByOrderByCreatedDateDesc(topFive).
+                stream()
+                .map(AdvertismentDtoRes::of)
+                .collect(Collectors.toList()));
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -23,8 +23,6 @@ public class CourseController {
             @ModelAttribute CourseGetAllReq courseGetAllReq
     ) {
         CourseGetAllRes courseAll = courseService.getAllCourses(courseGetAllReq);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(courseAll);
+        return ResponseEntity.ok(courseAll);
     }
 }

--- a/dateroad-domain/src/main/java/org/dateroad/adImage/domain/AdImage.java
+++ b/dateroad-domain/src/main/java/org/dateroad/adImage/domain/AdImage.java
@@ -1,0 +1,54 @@
+package org.dateroad.adImage.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dateroad.advertisement.domain.Advertisment;
+import org.dateroad.common.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Table(name = "ad_images")
+public class AdImage extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advertisment_id")
+    @NotNull
+    private Advertisment advertisment;
+
+    @Column(name = "image_url")
+    @NotNull
+    @Getter
+    private String imageUrl;
+
+    @Column(name = "sequence")
+    @NotNull
+    private int sequence;
+
+    public static AdImage create(final Advertisment advertisment, final String imageUrl, int sequence) {
+        return AdImage.builder()
+                .advertisment(advertisment)
+                .imageUrl(imageUrl)
+                .sequence(sequence)
+                .build();
+    }
+}

--- a/dateroad-domain/src/main/java/org/dateroad/adImage/domain/AdImage.java
+++ b/dateroad-domain/src/main/java/org/dateroad/adImage/domain/AdImage.java
@@ -37,14 +37,17 @@ public class AdImage extends BaseTimeEntity {
 
     @Column(name = "image_url")
     @NotNull
-    @Getter
     private String imageUrl;
 
     @Column(name = "sequence")
     @NotNull
     private int sequence;
 
-    public static AdImage create(final Advertisment advertisment, final String imageUrl, int sequence) {
+    public static AdImage create(
+            final Advertisment advertisment,
+            final String imageUrl,
+            final int sequence
+    ) {
         return AdImage.builder()
                 .advertisment(advertisment)
                 .imageUrl(imageUrl)

--- a/dateroad-domain/src/main/java/org/dateroad/adImage/repository/AdImageRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/adImage/repository/AdImageRepository.java
@@ -1,0 +1,11 @@
+package org.dateroad.adImage.repository;
+
+import java.util.List;
+import org.dateroad.adImage.domain.AdImage;
+import org.dateroad.advertisement.domain.Advertisment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdImageRepository extends JpaRepository<AdImage, Long> {
+}

--- a/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/AdTagType.java
+++ b/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/AdTagType.java
@@ -1,0 +1,5 @@
+package org.dateroad.advertisement.domain;
+
+public enum AdTagType {
+    EDITOR,AD,ABOUT,HOT
+}

--- a/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/AdTagType.java
+++ b/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/AdTagType.java
@@ -1,5 +1,8 @@
 package org.dateroad.advertisement.domain;
 
 public enum AdTagType {
-    EDITOR,AD,ABOUT,HOT
+    EDITOR,
+    AD,
+    ABOUT,
+    HOT
 }

--- a/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/Advertisment.java
+++ b/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/Advertisment.java
@@ -45,8 +45,11 @@ public class Advertisment extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private AdTagType tag;
 
-
-    public static Advertisment create(final String title, final String description,final String thumbnail, AdTagType tag) {
+    public static Advertisment create(
+            final String title,
+            final String description,
+            final String thumbnail,
+            final AdTagType tag) {
         return Advertisment.builder()
                 .title(title)
                 .description(description)
@@ -54,5 +57,4 @@ public class Advertisment extends BaseTimeEntity {
                 .tag(tag)
                 .build();
     }
-
 }

--- a/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/Advertisment.java
+++ b/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/Advertisment.java
@@ -2,6 +2,8 @@ package org.dateroad.advertisement.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,10 +36,23 @@ public class Advertisment extends BaseTimeEntity {
     @NotNull
     private String description;
 
-    public static Advertisment create(final String title, final String description) {
+    @Column(name = "thumbnail")
+    @NotNull
+    private String thumbnail;
+
+    @Column(name = "tag")
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AdTagType tag;
+
+
+    public static Advertisment create(final String title, final String description,final String thumbnail, AdTagType tag) {
         return Advertisment.builder()
                 .title(title)
                 .description(description)
+                .thumbnail(thumbnail)
+                .tag(tag)
                 .build();
     }
+
 }

--- a/dateroad-domain/src/main/java/org/dateroad/advertisement/repository/AdvertismentRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/advertisement/repository/AdvertismentRepository.java
@@ -1,0 +1,14 @@
+package org.dateroad.advertisement.repository;
+
+import java.util.List;
+import org.dateroad.advertisement.domain.Advertisment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdvertismentRepository extends JpaRepository<Advertisment, Long> {
+    @Query("SELECT a FROM Advertisment a ORDER BY a.createdAt DESC")
+    List<Advertisment> findTop5ByOrderByCreatedDateDesc(Pageable pageable);
+}


### PR DESCRIPTION
## 🔥*Pull requests*
광고 전체 조회 API 구현 입니다.
⛳️ **작업한 브랜치**
- feature/#29

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 광고 Controller 구현
- 광고 Service 구현
- 광고 필드 thumbnail 추가
- https://github.com/TeamDATEROAD/DATEROAD-SERVER/blob/95d2c7f08df8e747a86a5656b4e40056751ceaef/dateroad-domain/src/main/java/org/dateroad/advertisement/domain/Advertisment.java#L39-L46
- 광고 사용이미지 AdImage Entity 추가
   - Course와 Date 에서 연결된 Image 엔티티와 같습니다.
- 광고 관련 Dto 구현 
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 광고 Entity와 AdImage 를 전부 분리하는 경우 
  - 광고를 조회하는경우 AdImage 쿼리가 추가적으로 계속 나가는 문제점
  - 생성시점에 thumnail로 이미지 하나를 저장하는 방식으로 Query 1개로 줄일수 있는 방식으로 광고 엔티티에 thumnbnail필드 추가했습니다. 
## 📟 관련 이슈
- Resolved: #29 