### PR TITLE
[FEAT] 로그인 API 구현 - #34

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/auth/config/SecurityConfig.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/config/SecurityConfig.java
@@ -26,8 +26,8 @@ public class SecurityConfig {
     private static final String[] whiteList = {
             "/actuator/health",
             "/api/v1/users/signup",
-            "/api/users/signin",
-            "/api/users/reissue",
+            "/api/v1/users/signin",
+            "/api/v1/users/reissue",
             "/",
             "/swagger-ui/**",
             "/error",

--- a/dateroad-api/src/main/java/org/dateroad/auth/filter/JwtAuthenticationFilter.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/filter/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(accessToken) && accessToken.startsWith(Constants.BEARER)) {
             return accessToken.substring(Constants.BEARER.length());
         }
-        throw new UnauthorizedException(FailureCode.INVALID_ACCESS_TOKEN_VALUE);
+        throw new UnauthorizedException(FailureCode.UNAUTHORIZED);
     }
 
     private void doAuthentication(final String token, final long userId) {

--- a/dateroad-api/src/main/java/org/dateroad/users/api/UserController.java
+++ b/dateroad-api/src/main/java/org/dateroad/users/api/UserController.java
@@ -1,7 +1,9 @@
 package org.dateroad.users.api;
 
 import lombok.RequiredArgsConstructor;
+import org.dateroad.users.dto.request.UserSignInReq;
 import org.dateroad.users.dto.request.UserSignUpReq;
+import org.dateroad.users.dto.response.UserSignInRes;
 import org.dateroad.users.dto.response.UsersignUpRes;
 import org.dateroad.users.service.AuthService;
 import org.springframework.http.HttpStatus;
@@ -23,5 +25,13 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(userSignUpRes);
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<UserSignInRes> signIn(@RequestHeader(AUTHORIZATION) final String token,
+                                                @RequestBody final UserSignInReq userSignInReq) {
+        UserSignInRes userSignInRes = authService.signIn(token, userSignInReq);
+        return ResponseEntity
+                .ok(userSignInRes);
     }
 }

--- a/dateroad-api/src/main/java/org/dateroad/users/dto/request/UserSignInReq.java
+++ b/dateroad-api/src/main/java/org/dateroad/users/dto/request/UserSignInReq.java
@@ -1,0 +1,8 @@
+package org.dateroad.users.dto.request;
+
+import org.dateroad.user.domain.Platform;
+
+public record UserSignInReq(
+        Platform platform
+) {
+}

--- a/dateroad-api/src/main/java/org/dateroad/users/dto/response/UserSignInRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/users/dto/response/UserSignInRes.java
@@ -1,0 +1,20 @@
+package org.dateroad.users.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserSignInRes(
+        Long userId,
+        String accessToken,
+        String refreshToken
+) {
+    public static UserSignInRes of(final long userId, final String accessToken, final String refreshToken) {
+        return UserSignInRes.builder()
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/users/service/AuthService.java
+++ b/dateroad-api/src/main/java/org/dateroad/users/service/AuthService.java
@@ -5,16 +5,20 @@ import org.dateroad.auth.jwt.JwtProvider;
 import org.dateroad.auth.jwt.Token;
 import org.dateroad.code.FailureCode;
 import org.dateroad.exception.ConflictException;
+import org.dateroad.exception.EntityNotFoundException;
 import org.dateroad.exception.InvalidValueException;
 import org.dateroad.feign.apple.ApplePlatformUserIdProvider;
 import org.dateroad.feign.kakao.KakaoPlatformUserIdProvider;
+import org.dateroad.refreshtoken.repository.RefreshTokenRepository;
 import org.dateroad.tag.domain.DateTagType;
 import org.dateroad.tag.domain.UserTag;
 import org.dateroad.tag.repository.UserTagRepository;
 import org.dateroad.user.domain.Platform;
 import org.dateroad.user.domain.User;
 import org.dateroad.user.repository.UserRepository;
+import org.dateroad.users.dto.request.UserSignInReq;
 import org.dateroad.users.dto.request.UserSignUpReq;
+import org.dateroad.users.dto.response.UserSignInRes;
 import org.dateroad.users.dto.response.UsersignUpRes;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +33,7 @@ public class AuthService {
     private final ApplePlatformUserIdProvider applePlatformUserIdProvider;
     private final UserTagRepository userTagRepository;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public UsersignUpRes signUp(final String token, final UserSignUpReq userSignUpReq) {
@@ -40,6 +45,14 @@ public class AuthService {
         Token issuedToken = jwtProvider.issueToken(newUser.getId());
 
         return UsersignUpRes.of(newUser.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
+    }
+
+    @Transactional
+    public UserSignInRes signIn(final String token, final UserSignInReq userSignInReq) {
+        String platformUserId = getUserPlatformId(userSignInReq.platform(), token);
+        User foundUser = getUser(userSignInReq.platform(), platformUserId);
+        Token issuedToken = jwtProvider.issueToken(foundUser.getId());
+        return UserSignInRes.of(foundUser.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
     }
 
     private String getUserPlatformId(final Platform platform, final String token) {
@@ -71,6 +84,12 @@ public class AuthService {
                 .map(dateTagType -> UserTag.create(savedUser, dateTagType))
                 .map(userTagRepository::save)
                 .toList();
+    }
+
+    //유저 가져오기(검색)
+    private User getUser(final Platform platform, final String platformUserId) {
+        return userRepository.findUserByPlatFormAndPlatformUserId(platform, platformUserId)
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
     }
 
     private void validateUserTagSize(final List<DateTagType> userTags) {

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -46,6 +46,7 @@ public enum FailureCode {
      */
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
     TOKEN_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4041", "찾을 수 없는 토큰 타입입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "e4042", "존재하지 않는 회원입니다."),
 
     /**
      * 405 Method Not Allowed

--- a/dateroad-domain/src/main/java/org/dateroad/user/repository/UserRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/user/repository/UserRepository.java
@@ -4,6 +4,10 @@ import org.dateroad.user.domain.Platform;
 import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsUserByPlatFormAndPlatformUserId(final Platform platform, final String platformUserId);
+
+    Optional<User> findUserByPlatFormAndPlatformUserId(final Platform platform, final String platformUserId);
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#34

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 로그인 메서드 구현
- 로그인 할 때도, 액세스토큰과 리프레시토큰을 함께 재발급 해주었습니다.
```java
    @Transactional
    public UserSignInRes signIn(final String token, final UserSignInReq userSignInReq) {
        String platformUserId = getUserPlatformId(userSignInReq.platform(), token);
        User foundUser = getUser(userSignInReq.platform(), platformUserId);
        Token issuedToken = jwtProvider.issueToken(foundUser.getId());
        return UserSignInRes.of(foundUser.getId(), issuedToken.accessToken(), issuedToken.refreshToken());
    }
```


## 📟 관련 이슈
- Resolved: #34