### PR TITLE
[FEAT] 데이트 일정 삭제 API 구현 - #36

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/auth/config/SecurityConfig.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.dateroad.auth.exception.JwtAuthenticationEntryPoint;
 import org.dateroad.auth.filter.JwtAuthenticationFilter;
 import org.dateroad.auth.jwt.JwtProvider;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
@@ -20,4 +20,11 @@ public class DateController {
         dateService.createDate(userId, dateCreateReq);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @DeleteMapping("/{dateId}")
+    public ResponseEntity<Void> deleteDate(@UserId final Long userId,
+                                           @PathVariable final Long dateId) {
+        dateService.deleteDate(userId, dateId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -47,10 +47,16 @@ public class DateService {
     }
 
     private void createDateTag(Date date, List<TagCreateReq> tags) {
-        tags.forEach(t -> dateTagRepository.save(DateTag.create(date, t.tag())));
+        List<DateTag> dateTags = tags.stream()
+                .map(t -> DateTag.create(date, t.tag())).toList();
+
+        dateTagRepository.saveAll(dateTags);
     }
 
     private void createDatePlace(Date date, List<PlaceCreateReq> places) {
-        places.forEach(p -> datePlaceRepository.save(DatePlace.create(date, p.name(), p.duration(), p.sequence())));
+        List<DatePlace> datePlaces = places.stream()
+                        .map(p -> DatePlace.create(date, p.name(), p.duration(), p.sequence())).toList();
+
+        datePlaceRepository.saveAll(datePlaces);
     }
 }

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -9,6 +9,7 @@ import org.dateroad.date.dto.request.TagCreateReq;
 import org.dateroad.date.repository.DatePlaceRepository;
 import org.dateroad.date.repository.DateTagRepository;
 import org.dateroad.exception.EntityNotFoundException;
+import org.dateroad.exception.ForbiddenException;
 import org.dateroad.place.domain.DatePlace;
 import org.dateroad.tag.domain.DateTag;
 import org.dateroad.user.domain.User;
@@ -35,6 +36,16 @@ public class DateService {
         createDatePlace(date, dateCreateReq.places());
     }
 
+    @Transactional
+    public void deleteDate(Long userId, Long dateId) {
+        User findUser = getUser(userId);
+        Date findDate = getDate(dateId);
+        validateDate(findUser, findDate);
+        datePlaceRepository.deleteByDateId(dateId);
+        dateTagRepository.deleteByDateId(dateId);
+        dateRepository.deleteById(dateId);
+    }
+
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
@@ -49,14 +60,23 @@ public class DateService {
     private void createDateTag(Date date, List<TagCreateReq> tags) {
         List<DateTag> dateTags = tags.stream()
                 .map(t -> DateTag.create(date, t.tag())).toList();
-
         dateTagRepository.saveAll(dateTags);
     }
 
     private void createDatePlace(Date date, List<PlaceCreateReq> places) {
         List<DatePlace> datePlaces = places.stream()
                         .map(p -> DatePlace.create(date, p.name(), p.duration(), p.sequence())).toList();
-
         datePlaceRepository.saveAll(datePlaces);
+    }
+
+    private Date getDate(Long dateId) {
+        return dateRepository.findById(dateId)
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.DATE_NOT_FOUND));
+    }
+
+    private void validateDate(User findUser, Date findDate) {
+        if (!findUser.equals(findDate.getUser())) {
+            throw new ForbiddenException(FailureCode.DATE_DELETE_ACCESS_DENIED);
+        }
     }
 }

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -40,6 +40,7 @@ public enum FailureCode {
      * 403 Forbidden
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, "e4030", "리소스 접근 권한이 없습니다."),
+    DATE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "e4032", "해당 일정을 삭제할 권한이 없습니다."),
 
     /**
      * 404 Not Found
@@ -48,6 +49,7 @@ public enum FailureCode {
     TOKEN_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4041", "찾을 수 없는 토큰 타입입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "e4042", "유저를 찾을 수 없습니다."),
     COURSE_THUMBNAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "e4043", "코스 썸네일을 찾을수 없습니다."),
+    DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4044", "데이트를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/dateroad-common/src/main/java/org/dateroad/exception/ForbiddenException.java
+++ b/dateroad-common/src/main/java/org/dateroad/exception/ForbiddenException.java
@@ -1,0 +1,13 @@
+package org.dateroad.exception;
+
+import org.dateroad.code.FailureCode;
+
+public class ForbiddenException extends DateRoadException {
+    public ForbiddenException() {
+        super(FailureCode.FORBIDDEN);
+    }
+
+    public ForbiddenException(FailureCode failureCode) {
+        super(failureCode);
+    }
+}

--- a/dateroad-domain/src/main/java/org/dateroad/date/domain/Course.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/domain/Course.java
@@ -38,6 +38,10 @@ public class Course extends DateBase {
     @NotNull
     private int cost;
 
+    @Column(name = "thumbnail")
+    @NotNull
+    private String thumbnail;
+
     public static Course create(final String title, final String description,
                                 final String country, final String city,
                                 final int cost, final LocalDate date,

--- a/dateroad-domain/src/main/java/org/dateroad/date/domain/DateBase.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/domain/DateBase.java
@@ -46,8 +46,4 @@ public abstract class DateBase extends BaseTimeEntity {
     @Column(name = "city")
     @NotNull
     private String city;
-
-    @Column(name = "thumbnail")
-    @NotNull
-    private String thumbnail;
 }

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/DatePlaceRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/DatePlaceRepository.java
@@ -4,4 +4,5 @@ import org.dateroad.place.domain.DatePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DatePlaceRepository extends JpaRepository<DatePlace, Long> {
+    void deleteByDateId(Long dateId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/DateTagRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/DateTagRepository.java
@@ -4,4 +4,5 @@ import org.dateroad.tag.domain.DateTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DateTagRepository extends JpaRepository<DateTag, Long> {
+    void deleteByDateId(Long dateId);
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#36

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 일정 삭제 API를 구현했습니다.
userId와 dateId를 받아와 해당 데이트 일정이 userId의 User가 작성한 글이 맞을 경우에만 삭제가 가능하도록 하며, 다를 경우엔 예외를 터뜨리도록 구현했습니다.
또한, 엔티티 설계에서 양방향 설계를 하지 않았기 때문에 cascade 옵션을 사용할 수 없었습니다.
양방향 설계를 진행해 cascade를 활용한 삭제를 진행하는 방법도 고려해봤지만, DB 관리시 위험성과 softDelete와 같은 앞으로의 확장성을 위해 우선은 직접 관련된 entity의 Repository에서 해당 id의 db를 직접 지워주도록 구현했습니다.

```
    @Transactional
    public void deleteDate(final Long userId, final Long dateId) {
        User findUser = getUser(userId);
        Date findDate = getDate(dateId);
        validateDate(findUser, findDate);
        datePlaceRepository.deleteByDateId(dateId);
        dateTagRepository.deleteByDateId(dateId);
        dateRepository.deleteById(dateId);
    }
```

![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/102401928/aa9a9af2-82e1-4c9a-bb6c-b91e2d314b9e)

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
https://www.inflearn.com/questions/31969/cascade-%EC%98%B5%EC%85%98-%EC%A7%88%EB%AC%B8

## 📟 관련 이슈
- Resolved: #36