### PR TITLE
[FEAT] 데이트 일정 상세 조회 API 구현 - #37

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
@@ -3,6 +3,7 @@ package org.dateroad.date.api;
 import lombok.RequiredArgsConstructor;
 import org.dateroad.auth.argumentresolve.UserId;
 import org.dateroad.date.dto.request.DateCreateReq;
+import org.dateroad.date.dto.response.DateDetailRes;
 import org.dateroad.date.service.DateService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,13 @@ public class DateController {
                                            @RequestBody final DateCreateReq dateCreateReq) {
         dateService.createDate(userId, dateCreateReq);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/{dateId}")
+    public ResponseEntity<DateDetailRes> getDateDetail(@RequestHeader final Long userId,
+                                                       @PathVariable final Long dateId) {
+        DateDetailRes dateDetailRes = dateService.getDateDetail(userId, dateId);
+        return ResponseEntity.ok(dateDetailRes);
     }
 
     @DeleteMapping("/{dateId}")

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
@@ -1,0 +1,43 @@
+package org.dateroad.date.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.dateroad.date.domain.Date;
+import org.dateroad.place.domain.DatePlace;
+import org.dateroad.tag.domain.DateTag;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DateDetailRes(
+    Long dateId,
+    String title,
+    LocalTime startAt,
+    String city,
+    List<TagGetRes> tags,
+    LocalDate date,
+    List<PlaceGetRes> places
+) {
+
+    public static DateDetailRes of(Date date, List<DateTag> tags, List<DatePlace> places) {
+
+        List<TagGetRes> tagGetRes = tags.stream()
+                .map(TagGetRes::of)
+                .toList();
+
+        List<PlaceGetRes> placeGetRes = places.stream()
+                .map(PlaceGetRes::of)
+                .toList();
+
+        return DateDetailRes.builder()
+                .dateId(date.getId())
+                .title(date.getTitle())
+                .startAt(date.getStartAt())
+                .tags(tagGetRes)
+                .date(date.getDate())
+                .places(placeGetRes)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/PlaceGetRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/PlaceGetRes.java
@@ -1,0 +1,21 @@
+package org.dateroad.date.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.dateroad.place.domain.DatePlace;
+
+@Builder(access = AccessLevel.PRIVATE)
+
+public record PlaceGetRes(
+        String name,
+        float duration,
+        int sequence
+) {
+    public static PlaceGetRes of(DatePlace datePlace) {
+        return PlaceGetRes.builder()
+                .name(datePlace.getName())
+                .duration(datePlace.getDuration())
+                .sequence(datePlace.getSequence())
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/TagGetRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/TagGetRes.java
@@ -1,0 +1,17 @@
+package org.dateroad.date.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.dateroad.tag.domain.DateTag;
+import org.dateroad.tag.domain.DateTagType;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record TagGetRes(
+        DateTagType tag
+) {
+    public static TagGetRes of(DateTag dateTag) {
+        return TagGetRes.builder()
+                .tag(dateTag.getDateTagType())
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -29,7 +29,7 @@ public class DateService {
     private final DatePlaceRepository datePlaceRepository;
 
     @Transactional
-    public void createDate(Long userId, DateCreateReq dateCreateReq) {
+    public void createDate(final Long userId, final DateCreateReq dateCreateReq) {
         User findUser = getUser(userId);
         Date date = createDate(findUser, dateCreateReq);
         createDateTag(date, dateCreateReq.tags());
@@ -37,7 +37,7 @@ public class DateService {
     }
 
     @Transactional
-    public void deleteDate(Long userId, Long dateId) {
+    public void deleteDate(final Long userId, final Long dateId) {
         User findUser = getUser(userId);
         Date findDate = getDate(dateId);
         validateDate(findUser, findDate);

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -6,6 +6,7 @@ import org.dateroad.date.domain.Date;
 import org.dateroad.date.dto.request.DateCreateReq;
 import org.dateroad.date.dto.request.PlaceCreateReq;
 import org.dateroad.date.dto.request.TagCreateReq;
+import org.dateroad.date.dto.response.DateDetailRes;
 import org.dateroad.date.repository.DatePlaceRepository;
 import org.dateroad.date.repository.DateTagRepository;
 import org.dateroad.exception.EntityNotFoundException;
@@ -34,6 +35,15 @@ public class DateService {
         Date date = createDate(findUser, dateCreateReq);
         createDateTag(date, dateCreateReq.tags());
         createDatePlace(date, dateCreateReq.places());
+    }
+
+    public DateDetailRes getDateDetail(final Long userId, final Long dateId) {
+        User findUser = getUser(userId);
+        Date findDate = getDate(dateId);
+        validateDate(findUser, findDate);
+        List<DateTag> findDateTags = getDateTag(findDate);
+        List<DatePlace> findDatePlaces = getDatePlace(findDate);
+        return DateDetailRes.of(findDate, findDateTags, findDatePlaces);
     }
 
     @Transactional
@@ -78,5 +88,21 @@ public class DateService {
         if (!findUser.equals(findDate.getUser())) {
             throw new ForbiddenException(FailureCode.DATE_DELETE_ACCESS_DENIED);
         }
+    }
+
+    private List<DateTag> getDateTag(Date date) {
+        List<DateTag> dateTags = dateTagRepository.findByDate(date);
+        if (dateTags == null | dateTags.isEmpty()) {
+            throw new EntityNotFoundException(FailureCode.DATE_TAG_NOT_FOUND);
+        }
+        return dateTags;
+    }
+
+    private List<DatePlace> getDatePlace(Date date) {
+        List<DatePlace> datePlaces = datePlaceRepository.findByDate(date);
+        if (datePlaces == null | datePlaces.isEmpty()) {
+            throw new EntityNotFoundException(FailureCode.DATE_PLACE_NOT_FOUND);
+        }
+        return datePlaces;
     }
 }

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -40,7 +40,7 @@ public enum FailureCode {
      * 403 Forbidden
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, "e4030", "리소스 접근 권한이 없습니다."),
-    DATE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "e4032", "해당 일정을 삭제할 권한이 없습니다."),
+    DATE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "e4032", "해당 일정에 권한이 없습니다."),
 
     /**
      * 404 Not Found
@@ -50,6 +50,8 @@ public enum FailureCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "e4042", "유저를 찾을 수 없습니다."),
     COURSE_THUMBNAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "e4043", "코스 썸네일을 찾을수 없습니다."),
     DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4044", "데이트를 찾을 수 없습니다."),
+    DATE_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "e4045", "데이트 태그를 찾을 수 없습니다."),
+    DATE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4046", "데이트 장소를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed

--- a/dateroad-domain/src/main/java/org/dateroad/date/domain/Date.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/domain/Date.java
@@ -10,12 +10,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.dateroad.user.domain.User;
 
 @Entity
 @SuperBuilder
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "dates")

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/DatePlaceRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/DatePlaceRepository.java
@@ -1,8 +1,12 @@
 package org.dateroad.date.repository;
 
+import org.dateroad.date.domain.Date;
 import org.dateroad.place.domain.DatePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DatePlaceRepository extends JpaRepository<DatePlace, Long> {
     void deleteByDateId(Long dateId);
+    List<DatePlace> findByDate(Date date);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/DateTagRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/DateTagRepository.java
@@ -1,8 +1,12 @@
 package org.dateroad.date.repository;
 
+import org.dateroad.date.domain.Date;
 import org.dateroad.tag.domain.DateTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface DateTagRepository extends JpaRepository<DateTag, Long> {
     void deleteByDateId(Long dateId);
+    List<DateTag> findByDate(Date date);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/tag/domain/DateTag.java
+++ b/dateroad-domain/src/main/java/org/dateroad/tag/domain/DateTag.java
@@ -13,14 +13,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.dateroad.common.BaseTimeEntity;
 import org.dateroad.date.domain.Date;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#37

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 일정 상세 조회 API를 구현했습니다.
userId와 dateId를 받아와 해당 데이트 일정이 userId의 User가 작성한 글이 맞을 경우에만 조회 가능하도록 하며, 다를 경우엔 예외를 터뜨리도록 구현했습니다.
또한, 확장성을 위해 DateDeailRes에 있는 TagGetRes, PlaceGetRes를 각각의 record로 따로 구현해 뒀습니다.
findDateTags와 findDatePlaces에서 사용되는 각각 사용되는 findByDate을 List로 받아와 null을 방지하기 위해 dateTags == null | dateTags.isEmpty() 으로 검증해주는 방식으로 코드를 구현했습니다.

ref: https://velog.io/@hnsoo/JPA-%EC%9E%98%EB%AA%BB%EB%90%9C-%ED%91%9C%ED%98%84-OptionalListobject

더 좋은 검증방법이 있다면 추천해주세요,,ㅎㅎ

```
    public DateDetailRes getDateDetail(final Long userId, final Long dateId) {
        User findUser = getUser(userId);
        Date findDate = getDate(dateId);
        validateDate(findUser, findDate);
        List<DateTag> findDateTags = getDateTag(findDate);
        List<DatePlace> findDatePlaces = getDatePlace(findDate);
        return DateDetailRes.of(findDate, findDateTags, findDatePlaces);
    }
```

![image](https://github.com/TeamDATEROAD/DATEROAD-SERVER/assets/102401928/08546e09-1d10-4dd4-a691-8752f61f0f12)


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #37