### PR TITLE
[FEAT] 지난 & 다가올 데이트 일정 전체 조회 API 구현 - #38

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
@@ -23,7 +23,7 @@ public class DateController {
     }
 
     @GetMapping("/{dateId}")
-    public ResponseEntity<DateDetailRes> getDateDetail(@RequestHeader final Long userId,
+    public ResponseEntity<DateDetailRes> getDateDetail(@UserId final Long userId,
                                                        @PathVariable final Long dateId) {
         DateDetailRes dateDetailRes = dateService.getDateDetail(userId, dateId);
         return ResponseEntity.ok(dateDetailRes);

--- a/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
@@ -25,7 +25,7 @@ public class DateController {
 
     @GetMapping
     public ResponseEntity<DatesGetRes> getDates(@UserId final Long userId,
-                                                  @RequestParam final String time) {
+                                                @RequestParam final String time) {
         DatesGetRes datesGetRes = dateService.getDates(userId, time);
         return ResponseEntity.ok(datesGetRes);
     }

--- a/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/api/DateController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.dateroad.auth.argumentresolve.UserId;
 import org.dateroad.date.dto.request.DateCreateReq;
 import org.dateroad.date.dto.response.DateDetailRes;
+import org.dateroad.date.dto.response.DatesGetRes;
 import org.dateroad.date.service.DateService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,13 @@ public class DateController {
                                            @RequestBody final DateCreateReq dateCreateReq) {
         dateService.createDate(userId, dateCreateReq);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<DatesGetRes> getDates(@UserId final Long userId,
+                                                  @RequestParam final String time) {
+        DatesGetRes datesGetRes = dateService.getDates(userId, time);
+        return ResponseEntity.ok(datesGetRes);
     }
 
     @GetMapping("/{dateId}")

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
@@ -1,5 +1,6 @@
 package org.dateroad.date.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 import org.dateroad.date.domain.Date;
@@ -14,9 +15,11 @@ import java.util.List;
 public record DateDetailRes(
     Long dateId,
     String title,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     LocalTime startAt,
     String city,
     List<TagGetRes> tags,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     LocalDate date,
     List<PlaceGetRes> places
 ) {

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateGetRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateGetRes.java
@@ -1,0 +1,34 @@
+package org.dateroad.date.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.dateroad.date.domain.Date;
+import org.dateroad.tag.domain.DateTag;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DateGetRes(
+        Long dateId,
+        String title,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+        LocalDate date,
+        String city,
+        List<TagGetRes> tags,
+        int dDay
+) {
+    public static DateGetRes of(Date date, List<DateTag> tags, int dDay) {
+        return DateGetRes.builder()
+                .dateId(date.getId())
+                .title(date.getTitle())
+                .date(date.getDate())
+                .city(date.getCity())
+                .tags(tags.stream()
+                        .map(TagGetRes::of)
+                        .toList())
+                .dDay(dDay)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/DatesGetRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/DatesGetRes.java
@@ -1,0 +1,17 @@
+package org.dateroad.date.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DatesGetRes(
+        List<DateGetRes> dates
+) {
+    public static DatesGetRes of(List<DateGetRes> dates) {
+        return DatesGetRes.builder()
+                .dates(dates)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
@@ -2,6 +2,16 @@ package org.dateroad.date.service;
 
 import org.dateroad.date.domain.Date;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface DateRepository extends JpaRepository<Date, Long> {
+    @Query("select d from Date d where d.user.id = :userId and d.date < :currentDate")
+    List<Date> findPastDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);
+
+    @Query("select d from Date d where d.user.id = :userId and d.date >= :currentDate")
+    List<Date> findFutureDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);
 }

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -42,7 +42,7 @@ public class DateService {
         createDatePlace(date, dateCreateReq.places());
     }
 
-    public DatesGetRes getDates(Long userId, String time) {
+    public DatesGetRes getDates(final Long userId, final String time) {
         LocalDate currentDate = LocalDate.now();
         List<Date> dates = fetchDatesByUserIdAndTime(userId, time, currentDate);
         List<DateGetRes> dateGetResList = dates.stream()
@@ -70,30 +70,30 @@ public class DateService {
         dateRepository.deleteById(dateId);
     }
 
-    private User getUser(Long userId) {
+    private User getUser(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
     }
 
-    private Date createDate(User findUser, DateCreateReq dateCreateReq) {
+    private Date createDate(final User findUser, final DateCreateReq dateCreateReq) {
         Date date = Date.create(findUser, dateCreateReq.title(), dateCreateReq.date(),
                 dateCreateReq.startAt(), dateCreateReq.country(), dateCreateReq.city());
         return dateRepository.save(date);
     }
 
-    private void createDateTag(Date date, List<TagCreateReq> tags) {
+    private void createDateTag(final Date date, final List<TagCreateReq> tags) {
         List<DateTag> dateTags = tags.stream()
                 .map(t -> DateTag.create(date, t.tag())).toList();
         dateTagRepository.saveAll(dateTags);
     }
 
-    private void createDatePlace(Date date, List<PlaceCreateReq> places) {
+    private void createDatePlace(final Date date, final List<PlaceCreateReq> places) {
         List<DatePlace> datePlaces = places.stream()
                         .map(p -> DatePlace.create(date, p.name(), p.duration(), p.sequence())).toList();
         datePlaceRepository.saveAll(datePlaces);
     }
 
-    private List<Date> fetchDatesByUserIdAndTime(Long userId, String time, LocalDate currentDate) {
+    private List<Date> fetchDatesByUserIdAndTime(final Long userId, final String time, final LocalDate currentDate) {
         if (time.equalsIgnoreCase("PAST")) {
             return dateRepository.findPastDatesByUserId(userId, currentDate);
         }
@@ -105,28 +105,28 @@ public class DateService {
         }
     }
 
-    private DateGetRes createDateGetRes(Date date, LocalDate currentDate) {
+    private DateGetRes createDateGetRes(final Date date, final LocalDate currentDate) {
         int dDay = calculateDday(date.getDate(), currentDate);
         List<DateTag> dateTags = getDateTag(date);
         return DateGetRes.of(date, dateTags, dDay);
     }
 
-    private int calculateDday(LocalDate date, LocalDate currentDate) {
+    private int calculateDday(final LocalDate date, final LocalDate currentDate) {
         return (int) ChronoUnit.DAYS.between(currentDate, date);
     }
 
-    private Date getDate(Long dateId) {
+    private Date getDate(final Long dateId) {
         return dateRepository.findById(dateId)
                 .orElseThrow(() -> new EntityNotFoundException(FailureCode.DATE_NOT_FOUND));
     }
 
-    private void validateDate(User findUser, Date findDate) {
+    private void validateDate(final User findUser, final Date findDate) {
         if (!findUser.equals(findDate.getUser())) {
             throw new ForbiddenException(FailureCode.DATE_DELETE_ACCESS_DENIED);
         }
     }
 
-    private List<DateTag> getDateTag(Date date) {
+    private List<DateTag> getDateTag(final Date date) {
         List<DateTag> dateTags = dateTagRepository.findByDate(date);
         if (dateTags == null | dateTags.isEmpty()) {
             throw new EntityNotFoundException(FailureCode.DATE_TAG_NOT_FOUND);
@@ -134,7 +134,7 @@ public class DateService {
         return dateTags;
     }
 
-    private List<DatePlace> getDatePlace(Date date) {
+    private List<DatePlace> getDatePlace(final Date date) {
         List<DatePlace> datePlaces = datePlaceRepository.findByDate(date);
         if (datePlaces == null | datePlaces.isEmpty()) {
             throw new EntityNotFoundException(FailureCode.DATE_PLACE_NOT_FOUND);

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -38,6 +38,7 @@ public enum FailureCode {
     INVALID_KAKAO_ACCESS(HttpStatus.UNAUTHORIZED, "e4026", "잘못된 카카오 통신 접근입니다."),
     UN_LINK_WITH_KAKAO_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "e4027", "카카오 연결 끊기 통신에 실패했습니다"),
     INVALID_APPLE_TOKEN_ACCESS(HttpStatus.UNAUTHORIZED, "e4028", "잘못된 애플 토큰 통신 접근입니다."),
+    INVALID_DATE_GET_TYPE(HttpStatus.UNAUTHORIZED, "e4029", "잘못된 데이트 타입 검색입니다."),
 
     /**
      * 403 Forbidden


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#38

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
지난 & 다가올 데이트 일정 전체 조회 API를 구현했습니다.
@RequestParam의 String name으로 PAST/FUTURE을 받아 PAST일 경우 유저의 지난 일정을 전체 조회해주며, FUTURE일 경우 유저의 지나지 않은 일정을 전체 조회해줍니다.
API 재사용을 위해 각각의 상황을 @RequestParam로 받아 구현하게 됐습니다.

```
    public DatesGetRes getDates(Long userId, String time) {
        LocalDate currentDate = LocalDate.now();
        List<Date> dates = fetchDatesByUserIdAndTime(userId, time, currentDate);
        List<DateGetRes> dateGetResList = dates.stream()
                .map(date -> createDateGetRes(date, currentDate))
                .toList();
        return DatesGetRes.of(dateGetResList);
    }
```
Jpa QueryDSL을 통해 각각의 필터에 해당하는 Date를 리스트로 받아오며, DateGetRes를 List로 받은 DatesGetRes를 응답으로 받습니다.
추가로 ChronoUnit.DAYS.between를 사용해서 두 날짜의 시간 차를 구해서 디데이를 반환해줬습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #38