### PR TITLE
[FEAT] 데이트 코스 좋아요 삭제 API 구현 - #68

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/auth/filter/JwtAuthenticationFilter.java
+++ b/dateroad-api/src/main/java/org/dateroad/auth/filter/JwtAuthenticationFilter.java
@@ -9,10 +9,8 @@ import org.dateroad.auth.jwt.JwtProvider;
 import org.dateroad.code.FailureCode;
 import org.dateroad.common.Constants;
 import org.dateroad.exception.UnauthorizedException;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -22,7 +20,6 @@ import static org.dateroad.auth.filter.TokenAuthentication.createTokenAuthentica
 
 
 @RequiredArgsConstructor
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
 

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -65,4 +65,11 @@ public class CourseController {
         courseService.createCourseLike(userId, courseId);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/{courseId}/likes")
+    public ResponseEntity<Void> deleteCourseLike(@RequestHeader final Long userId,
+                                                  @PathVariable final Long courseId) {
+        courseService.deleteCourseLike(userId, courseId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -60,7 +60,7 @@ public class CourseController {
     }
 
     @PostMapping("/{courseId}/likes")
-    public ResponseEntity<Void> createCourseLlike(@UserId final Long userId,
+    public ResponseEntity<Void> createCourseLike(@UserId final Long userId,
                                                   @PathVariable final Long courseId) {
         courseService.createCourseLike(userId, courseId);
         return ResponseEntity.ok().build();

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -53,6 +53,14 @@ public class CourseService {
         saveCourseLike(findUser, findCourse);
     }
 
+    @Transactional
+    public void deleteCourseLike(Long userId, Long courseId) {
+        User findUser = getUser(userId);
+        Course findCourse = getCourse(courseId);
+        Like findLike = getLike(findUser, findCourse);
+        likeRepository.delete(findLike);
+    }
+
     private <T> List<CourseDtoGetRes> convertToDtoList(List<T> entities, Function<T, Course> converter) {
         return entities.stream()
                 .map(converter)
@@ -102,6 +110,11 @@ public class CourseService {
     private void saveCourseLike(User user, Course course) {
         Like like = Like.create(course, user);
         likeRepository.save(like);
+    }
+
+    private Like getLike(User findUser, Course findCourse) {
+        return likeRepository.findByUserAndCourse(findUser, findCourse)
+                .orElseThrow(() -> new EntityNotFoundException(FailureCode.LIKE_NOT_FOUND));
     }
 
     @Transactional

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -58,6 +58,7 @@ public enum FailureCode {
     DATE_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4046", "데이트 장소를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4047", "데이트 코스를 찾을 수 없습니다."),
     NEAREST_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4048", "다가오는 데이트를 찾을 수 없습니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "e4048", "해당 데이트 코스에 좋아요를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#69

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 코스 좋아요 삭제 API를 구현했습니다.

```
    @Transactional
    public void deleteCourseLike(Long userId, Long courseId) {
        User findUser = getUser(userId);
        Course findCourse = getCourse(courseId);
        Like findLike = getLike(findUser, findCourse);
        likeRepository.delete(findLike);
    }
```

User와 Course를 찾아서 그에 해당하는 좋아요가 존재하는 경우 해당 좋아요를 삭제하도록 구현했습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #69