### PR TITLE
[FEAT] 데이트 코스 필터링 조회(메인) API 구현  - #79

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -37,6 +37,12 @@ public class CourseController {
         return ResponseEntity.ok(courseAll);
     }
 
+    @GetMapping("/sort")
+    public ResponseEntity<CourseGetAllRes> getSortedCourses(final @RequestParam String sortBy) {
+        CourseGetAllRes courseSortedRes = courseService.getSortedCourses(sortBy);
+        return ResponseEntity.ok(courseSortedRes);
+    }
+
     @GetMapping("/date-access")
     public ResponseEntity<DateAccessGetAllRes> getAllDataAccesCourse(
             final @UserId Long userId

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -20,7 +20,6 @@ import org.dateroad.date.dto.response.CourseGetDetailRes;
 import org.dateroad.date.repository.CourseRepository;
 import org.dateroad.dateAccess.domain.DateAccess;
 import org.dateroad.dateAccess.repository.DateAccessRepository;
-import org.dateroad.exception.DateRoadException;
 import org.dateroad.exception.EntityNotFoundException;
 import org.dateroad.image.domain.Image;
 import org.dateroad.image.repository.ImageRepository;

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -62,8 +62,9 @@ public enum FailureCode {
     COURSE_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "e40410", "데이트 태그를 찾을 수 없습니다."),
     NEAREST_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40411", "다가오는 데이트를 찾을 수 없습니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40412", "해당 데이트 코스에 좋아요를 찾을 수 없습니다."),
+    INSUFFICIENT_USER_POINTS(HttpStatus.NOT_FOUND, "e40413", "유저의 포인트가 부족합니다."),
+    SORT_TYPE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "e4029", "해당 순서 타입을 찾을 수 없습니다."),
 
-    INSUFFICIENT_USER_POINTS(HttpStatus.NOT_FOUND, "e4048", "유저의 포인트가 부족합니다."),
     /**
      * 405 Method Not Allowed
      */

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -1,18 +1,20 @@
 package org.dateroad.date.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.dateroad.date.domain.Course;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-// CourseRepository.java
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> , JpaSpecificationExecutor<Course> {
     boolean existsByUserId(Long userId);
-
+    @Query("SELECT c FROM Course c LEFT JOIN Like l ON c.id = l.course.id GROUP BY c.id ORDER BY COUNT(l) DESC")
+    List<Course> findTopCoursesByLikes(Pageable pageable);
+    @Query("SELECT c FROM Course c ORDER BY c.createdAt DESC")
+    List<Course> findTopCoursesByCreatedAt(Pageable pageable);
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#79

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 코스 필터링 조회(메인) API를 구현했습니다.

```
    @GetMapping("/sort")
    public ResponseEntity<CourseGetAllRes> getSortedCourses(final @RequestParam String sortBy) {
        CourseGetAllRes courseSortedRes = courseService.getSortedCourses(sortBy);
        return ResponseEntity.ok(courseSortedRes);
    }
```
메인에서 최신순과 인기순으로 불러오는 API를 공통적으로 사용하기 위해 RequestParam으로 sortBy를 받아 조회 방법을 구별합니다.

```
    public CourseGetAllRes getSortedCourses(String sortBy) {
        List<Course> courses;
        if (sortBy.equalsIgnoreCase("POPULAR")) {
            courses = getCoursesSortedByLikes();
        } else if (sortBy.equalsIgnoreCase("LATEST")) {
            courses = getCoursesSortedByLatest();
        } else {
            throw new EntityNotFoundException(FailureCode.SORT_TYPE_NOT_FOUND);
        }
        List<CourseDtoGetRes> courseDtoGetResList = convertToDtoList(courses, Function.identity());
        return CourseGetAllRes.of(courseDtoGetResList);
    }
```
실제 받아온 값으로 CourseService 로직에서 값을 비교해 조회합니다.
각각 조회의 반환 갯수가 다르기 때문에 다른 메서드를 통해 구해줬으며, dto로 변환하는 것은 기존의 메서드를 재사용했습니다.

최신순일 경우 가장 최근에 작성한 코스가 3개 반환되며, 인기순일 경우 좋아요의 개수가 가장 많은 순으로 작성한 코스 5개가 반환됩니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #79