### PR TITLE
[FEAT] 유저 등록 데이트 코스 조회 API(내가 등록한 코스) 구현 - #80

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -61,6 +61,12 @@ public class CourseController {
         ).body(CourseCreateRes.of(course.getId()));
     }
 
+    @GetMapping("/users")
+    public ResponseEntity<DateAccessGetAllRes> getMyCourses(final @UserId Long userId) {
+        DateAccessGetAllRes dateAccessGetAllRes = courseService.getMyCourses(userId);
+        return ResponseEntity.ok(dateAccessGetAllRes);
+    }
+
     @PostMapping("/{courseId}/date-access")
     public ResponseEntity<Void> openCourse(
             @UserId final Long userId,

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -30,7 +30,7 @@ public class CourseController {
     private final AsyncService asyncService;
 
     @GetMapping
-    public ResponseEntity<CourseGetAllRes> getAllCourse(
+    public ResponseEntity<CourseGetAllRes> getAllCourses(
             final @ModelAttribute CourseGetAllReq courseGetAllReq
     ) {
         CourseGetAllRes courseAll = courseService.getAllCourses(courseGetAllReq);
@@ -38,7 +38,7 @@ public class CourseController {
     }
 
     @GetMapping("/date-access")
-    public ResponseEntity<DateAccessGetAllRes> getAllDataAccesCourse(
+    public ResponseEntity<DateAccessGetAllRes> getAllDataAccessCourse(
             final @UserId Long userId
     ) {
         DateAccessGetAllRes dateAccessGetAllRes = courseService.getAllDataAccessCourse(userId);

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -62,7 +62,6 @@ public class CourseService {
         return CourseGetAllRes.of(courseDtoGetResList);
     }
 
-
     @Transactional
     public void createCourseLike(final Long userId, final Long courseId) {
         User findUser = getUser(userId);
@@ -100,6 +99,13 @@ public class CourseService {
                 course.getCost(),
                 duration
         );
+    }
+
+    public DateAccessGetAllRes getMyCourses(Long userId) {
+        User findUser = getUser(userId);
+        List<Course> courses = courseRepository.findByUser(findUser);
+        List<CourseDtoGetRes> courseDtoGetResList = convertToDtoList(courses, Function.identity());
+        return DateAccessGetAllRes.of(courseDtoGetResList);
     }
 
     public DateAccessGetAllRes getAllDataAccessCourse(final Long userId) {

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -1,18 +1,16 @@
 package org.dateroad.date.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.dateroad.date.domain.Course;
+import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-// CourseRepository.java
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> , JpaSpecificationExecutor<Course> {
     boolean existsByUserId(Long userId);
-
+    List<Course> findByUser(User user);
 }
 

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -7,6 +7,7 @@ import org.dateroad.user.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#80

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
유저 등록 데이트 코스 조회 API(내가 등록한 코스)를 구현했습니다.

```
    public DateAccessGetAllRes getMyCourses(Long userId) {
        User findUser = getUser(userId);
        List<Course> courses = courseRepository.findByUser(findUser);
        List<CourseDtoGetRes> courseDtoGetResList = convertToDtoList(courses, Function.identity());
        return DateAccessGetAllRes.of(courseDtoGetResList);
    }

```
userId를 통해 User를 가져오고, 해당 User로 작성된 Course를 가져와서 Dto로 변환해서 반환해줍니다. 이때 변환하는 함수는 기존에 있는 함수를 재사용했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #80