### PR TITLE
[FIX] 데이트 일정 상세 조회 API 응답 스펙 변경 - #85

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/DateDetailRes.java
@@ -21,10 +21,11 @@ public record DateDetailRes(
     List<TagGetRes> tags,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     LocalDate date,
-    List<PlaceGetRes> places
+    List<PlaceGetRes> places,
+    int dDay
 ) {
 
-    public static DateDetailRes of(Date date, List<DateTag> tags, List<DatePlace> places) {
+    public static DateDetailRes of(Date date, List<DateTag> tags, List<DatePlace> places, int dDay) {
 
         List<TagGetRes> tagGetRes = tags.stream()
                 .map(TagGetRes::of)
@@ -41,6 +42,7 @@ public record DateDetailRes(
                 .tags(tagGetRes)
                 .date(date.getDate())
                 .places(placeGetRes)
+                .dDay(dDay)
                 .build();
     }
 }

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -54,12 +54,14 @@ public class DateService {
     }
 
     public DateDetailRes getDateDetail(final Long userId, final Long dateId) {
+        LocalDate currentDate = LocalDate.now();
         User findUser = getUser(userId);
         Date findDate = getDate(dateId);
         validateDate(findUser, findDate);
         List<DateTag> findDateTags = getDateTag(findDate);
         List<DatePlace> findDatePlaces = getDatePlace(findDate);
-        return DateDetailRes.of(findDate, findDateTags, findDatePlaces);
+        int dDay = calculateDDay(findDate.getDate(), currentDate);
+        return DateDetailRes.of(findDate, findDateTags, findDatePlaces, dDay);
     }
 
     @Transactional
@@ -76,7 +78,7 @@ public class DateService {
         LocalDate currentDate = LocalDate.now();
         LocalTime currentTime = LocalTime.now();
         User findUser = getUser(userId);
-        Date nearest = findNearestDate(findUser.getId(), currentDate, currentTime); ;
+        Date nearest = findNearestDate(findUser.getId(), currentDate, currentTime);
         int dDay = calculateDDay(nearest.getDate(), currentDate);
         return DateGetNearestRes
                 .of(


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#85

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
데이트 일정 상세 조회 API 응답 스펙 변경입니다.
기존에 dDay를 응답 객체에서 빼서 전달해줬기에, 추가해서 직접 구해서 반환해줬습니다. 

<img width="801" alt="image" src="https://github.com/user-attachments/assets/a88b6ebf-cacf-4225-9440-a5ddffa5d724">



## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #85 