### PR TITLE
[FEAT] 회원가입 API 에서 프로필 사진 S3 적용 - #78

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<UserJwtInfoRes> signUp(@RequestHeader(AUTHORIZATION) final String token,
-                                                 @RequestPart("usertest") final UserSignUpReq userSignUPReq,
+                                                 @RequestPart("userSignUpReq") final UserSignUpReq userSignUPReq,
                                                  @RequestPart("image") MultipartFile image,
                                                  @RequestPart("tag") List<DateTagType> tag //todo: 열람 데이트 코스 전체 조회 API 머지 후, TagEnum으로 변경해야됨
     ) throws IOException {

--- a/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
@@ -2,6 +2,7 @@ package org.dateroad.user.api;
 
 import lombok.RequiredArgsConstructor;
 import org.dateroad.auth.argumentresolve.UserId;
+import org.dateroad.tag.domain.DateTagType;
 import org.dateroad.user.dto.request.AppleWithdrawAuthCodeReq;
 import org.dateroad.user.dto.request.UserSignInReq;
 import org.dateroad.user.dto.request.UserSignUpReq;
@@ -13,6 +14,10 @@ import org.dateroad.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 import static org.dateroad.common.Constants.AUTHORIZATION;
 
@@ -25,8 +30,11 @@ public class UserController {
 
     @PostMapping("/signup")
     public ResponseEntity<UserJwtInfoRes> signUp(@RequestHeader(AUTHORIZATION) final String token,
-                                                 @RequestBody final UserSignUpReq userSignUPReq) {
-        UserJwtInfoRes userSignUpRes = authService.signUp(token, userSignUPReq);
+                                                 @RequestPart("usertest") final UserSignUpReq userSignUPReq,
+                                                 @RequestPart("image") MultipartFile image,
+                                                 @RequestPart("tag") List<DateTagType> tag //todo: 열람 데이트 코스 전체 조회 API 머지 후, TagEnum으로 변경해야됨
+    ) throws IOException {
+        UserJwtInfoRes userSignUpRes = authService.signUp(token, userSignUPReq, image, tag);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(userSignUpRes);

--- a/dateroad-api/src/main/java/org/dateroad/user/dto/request/UserSignUpReq.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/dto/request/UserSignUpReq.java
@@ -2,13 +2,12 @@ package org.dateroad.user.dto.request;
 
 import org.dateroad.tag.domain.DateTagType;
 import org.dateroad.user.domain.Platform;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public record UserSignUpReq(
         String name,
-        List<DateTagType> tag,  //todo: 열람 데이트 코스 전체 조회 API 머지 후, TagEnum으로 변경해야됨
-        String image,
         Platform platform
 ) {
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#78

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 회원가입 API 에서 프로필 사진 S3 적용 
```java
    @PostMapping("/signup")
    public ResponseEntity<UserJwtInfoRes> signUp(@RequestHeader(AUTHORIZATION) final String token,
                                                 @RequestPart("userSignUpReq") final UserSignUpReq userSignUPReq,
                                                 @RequestPart("image") MultipartFile image,
                                                 @RequestPart("tag") List<DateTagType> tag //todo: 열람 데이트 코스 전체 조회 API 머지 후, TagEnum으로 변경해야됨
    ) throws IOException {
        UserJwtInfoRes userSignUpRes = authService.signUp(token, userSignUPReq, image, tag);
        return ResponseEntity
                .status(HttpStatus.CREATED)
                .body(userSignUpRes);
    }
```

## 📟 관련 이슈
- Resolved: #78