### PR TITLE
[FEAT] 데이트 코스 삭제 API - #82

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseController.java
@@ -75,7 +75,6 @@ public class CourseController {
     public ResponseEntity<CourseGetDetailRes> getCourseDetail(@UserId Long userId,
                                                               @PathVariable("courseId") Long courseId) {
         CourseGetDetailRes courseGetDetailRes = courseService.getCourseDetail(userId, courseId);
-
         return ResponseEntity.ok(courseGetDetailRes);
     }
 
@@ -90,6 +89,13 @@ public class CourseController {
     public ResponseEntity<Void> deleteCourseLike(@RequestHeader final Long userId,
                                                   @PathVariable final Long courseId) {
         courseService.deleteCourseLike(userId, courseId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{courseId}")
+    public ResponseEntity<Void> deleteCourse(@UserId Long userId,
+                                                 @PathVariable final Long courseId) {
+        courseService.deleteCourse(userId, courseId);
         return ResponseEntity.ok().build();
     }
 }

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -16,12 +16,14 @@ import org.dateroad.course.dto.response.CourseGetAllRes;
 import org.dateroad.course.dto.response.DateAccessGetAllRes;
 import org.dateroad.course.facade.AsyncService;
 import org.dateroad.date.domain.Course;
+import org.dateroad.date.domain.Date;
 import org.dateroad.date.dto.response.CourseGetDetailRes;
 import org.dateroad.date.repository.CourseRepository;
 import org.dateroad.dateAccess.domain.DateAccess;
 import org.dateroad.dateAccess.repository.DateAccessRepository;
 import org.dateroad.exception.DateRoadException;
 import org.dateroad.exception.EntityNotFoundException;
+import org.dateroad.exception.ForbiddenException;
 import org.dateroad.image.domain.Image;
 import org.dateroad.image.repository.ImageRepository;
 import org.dateroad.exception.ConflictException;
@@ -54,14 +56,12 @@ public class CourseService {
     private final CoursePlaceRepository coursePlaceRepository;
     private final CourseTagRepository courseTagRepository;
 
-
     public CourseGetAllRes getAllCourses(final CourseGetAllReq courseGetAllReq) {
         Specification<Course> spec = CourseSpecifications.filterByCriteria(courseGetAllReq);
         List<Course> courses = courseRepository.findAll(spec);
         List<CourseDtoGetRes> courseDtoGetResList = convertToDtoList(courses, Function.identity());
         return CourseGetAllRes.of(courseDtoGetResList);
     }
-
 
     @Transactional
     public void createCourseLike(final Long userId, final Long courseId) {
@@ -227,7 +227,8 @@ public class CourseService {
                         tagList.getDateTagType())
                 ).toList();
 
-        boolean isAccess = dateAccessRepository.existsDateAccessByUserIdAndCourseId(foundUser.getId(), foundCourse.getId());
+        boolean isAccess = dateAccessRepository.existsDateAccessByUserIdAndCourseId(foundUser.getId(),
+                foundCourse.getId());
 
         int likesCount = likeRepository.countByCourse(foundCourse);
 
@@ -287,6 +288,25 @@ public class CourseService {
     private void validateCourseTag(final List<CourseTag> courseTags) {
         if (courseTags.isEmpty()) {
             throw new EntityNotFoundException(FailureCode.COURSE_TAG_NOT_FOUND);
+        }
+    }
+
+    @Transactional
+    public void deleteCourse(final Long userId, final Long courseId) {
+        User findUser = getUser(userId);
+        Course findCourse = getCourse(courseId);
+        validateCourse(findUser, findCourse);
+        likeRepository.deleteByCourse(courseId);
+        coursePlaceRepository.deleteByCourse(courseId);
+        courseTagRepository.deleteByCourse(courseId);
+        dateAccessRepository.deleteByCourse(courseId);
+        imageRepository.deleteByCourse(courseId);
+        courseRepository.deleteByCourse(courseId);
+    }
+
+    private void validateCourse(final User findUser, final Course findCourse) {
+        if (!findUser.equals(findCourse.getUser())) {
+            throw new ForbiddenException(FailureCode.COURSE_DELETE_ACCESS_DENIED);
         }
     }
 }

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -63,7 +63,7 @@ public enum FailureCode {
     NEAREST_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40411", "다가오는 데이트를 찾을 수 없습니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40412", "해당 데이트 코스에 좋아요를 찾을 수 없습니다."),
     ADVERTISMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "e40413", "해당 광고를 찾을 수 없습니다."),
-
+    COURSE_DELETE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "e40414", "해당 코스를 삭제할수 없습니다."),
     INSUFFICIENT_USER_POINTS(HttpStatus.NOT_FOUND, "e4048", "유저의 포인트가 부족합니다."),
     /**
      * 405 Method Not Allowed
@@ -79,6 +79,7 @@ public enum FailureCode {
     DUPLICATE_COURSE_LIKE(HttpStatus.CONFLICT, "e4093", "해당 데이트 코스에 좋아요가 이미 존재합니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5000", "서버 내부 오류입니다.");
+
 
     /**
      * 500 Internal Server Error

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -6,13 +6,19 @@ import java.util.Optional;
 import org.dateroad.date.domain.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 // CourseRepository.java
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> , JpaSpecificationExecutor<Course> {
     boolean existsByUserId(Long userId);
-
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM courses WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }
 

--- a/dateroad-domain/src/main/java/org/dateroad/dateAccess/repository/DateAccessRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/dateAccess/repository/DateAccessRepository.java
@@ -4,9 +4,11 @@ import java.util.List;
 import org.dateroad.date.domain.Course;
 import org.dateroad.dateAccess.domain.DateAccess;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface DateAccessRepository extends JpaRepository<DateAccess,Long> {
@@ -14,4 +16,9 @@ public interface DateAccessRepository extends JpaRepository<DateAccess,Long> {
     List<Course> findCoursesByUserId(@Param("userId") Long userId);
 
     boolean existsDateAccessByUserIdAndCourseId(Long userId, Long courseId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM date_access WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/image/repository/ImageRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/image/repository/ImageRepository.java
@@ -5,11 +5,20 @@ import java.util.Optional;
 import org.dateroad.date.domain.Course;
 import org.dateroad.image.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
     Optional<Image> findFirstByCourseOrderBySequenceAsc(Course course);
 
     List<Image> findAllByCourseId(Long courseId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM images WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
@@ -5,11 +5,20 @@ import org.dateroad.date.domain.Course;
 import org.dateroad.like.domain.Like;
 import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     int countByCourse(Course course);
     boolean existsByUserIdAndCourseId(Long userId, Long courseId);
     Optional<Like> findByUserAndCourse(User user, Course course);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM likes WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/place/repository/CoursePlaceRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/place/repository/CoursePlaceRepository.java
@@ -4,9 +4,11 @@ import java.util.List;
 import org.dateroad.date.domain.Course;
 import org.dateroad.place.domain.CoursePlace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CoursePlaceRepository extends JpaRepository<CoursePlace,Long> {
@@ -14,4 +16,9 @@ public interface CoursePlaceRepository extends JpaRepository<CoursePlace,Long> {
     Integer findTotalDurationByCourseId(@Param("courseId") Long courseId);
 
     List<CoursePlace> findAllCoursePlacesByCourseId(Long courseId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM course_places WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/tag/repository/CourseTagRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/tag/repository/CourseTagRepository.java
@@ -2,11 +2,20 @@ package org.dateroad.tag.repository;
 
 import org.dateroad.tag.domain.CourseTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CourseTagRepository extends JpaRepository<CourseTag,Long> {
     List<CourseTag> findAllCourseTagByCourseId(Long courseId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM course_tags WHERE course_id = :courseId", nativeQuery = true)
+    void deleteByCourse(@Param("courseId") Long courseId);
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#82

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
코스 삭제 API 구현
- 코스 Controller 구현 
- 코스 Service 구현
- 코스 Repository 및 코스 연관 엔티티 Repository 구현

<hr> 

- Spring에서 JPA를 사용할때는 영속화가 필요하지 않으므로 native query로 작동하게 구현했습니다.
- https://github.com/TeamDATEROAD/DATEROAD-SERVER/blob/ccb44598de1dd1f472468a23e11aaeb914747b40/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java#L19-L22
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #82 