### PR TITLE
[REFACTOR] 엔티티 변경에 따른 Course조회 로직 수정 - #116 

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
@@ -26,15 +26,6 @@ public class AsyncService {
     private final ImageService imageService;
     private final StringRedisTemplate redisTemplate;
 
-
-    public Image findFirstByCourseOrderBySequenceAsc(final Course course) {
-        return imageService.findFirstByCourseOrderBySequenceAsc(course);
-    }
-
-    public float findTotalDurationByCourseId(final Long id) {
-        return coursePlaceService.findTotalDurationByCourseId(id);
-    }
-
     @Transactional
     public List<Image> createImage(final List<MultipartFile> images, final Course course) {
         return imageService.saveImages(images, course);

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -109,14 +109,11 @@ public class CourseService {
 
     private CourseDtoGetRes convertToDto(final Course course) {
         int likeCount = likeRepository.countByCourse(course);
-        Image thumbnailImage = asyncService.findFirstByCourseOrderBySequenceAsc(course);
-        String thumbnailUrl = thumbnailImage != null ? thumbnailImage.getImageUrl() : null;
-        float duration = asyncService.findTotalDurationByCourseId(course.getId());
         return CourseDtoGetRes.of(
                 course,
-                thumbnailUrl,
+                course.getThumbnail(),
                 likeCount,
-                duration
+                course.getTime()
         );
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#116

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 기존 코스 조회 로직 
- 코스 -> 코스 연관 place, 코스 연관 image 테이블에서 id로 조회후 가져와 계산하는 로직
- 코스 -> 코스 자체 cost, time, thumnail 추출 

: result : 
db조회 횟수 2제거 

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #116 