### PR TITLE
[FIX] 만단위 -> 원단위로 변경 - #136

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseSpecifications.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseSpecifications.java
@@ -17,7 +17,8 @@ public class CourseSpecifications {
         return (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
             addPredicate(predicates, criteriaBuilder, root, "city", courseGetAllReq.city(), criteriaBuilder::equal);
-            addPredicate(predicates, criteriaBuilder, root, "country", courseGetAllReq.country(), criteriaBuilder::equal);
+            addPredicate(predicates, criteriaBuilder, root, "country", courseGetAllReq.country(),
+                    criteriaBuilder::equal);
             addCostPredicate(predicates, criteriaBuilder, root, courseGetAllReq.cost());
             return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
         };
@@ -32,14 +33,27 @@ public class CourseSpecifications {
                 );
     }
 
-    private static void addCostPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<?> root, Integer cost) {
+    private static void addCostPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<?> root,
+                                         Integer cost) {
         if (cost != null) {
-            if (cost == 11) {
-                predicates.add(criteriaBuilder.greaterThan(root.get("cost"), 10));
-            } else {
-                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), cost));
+            switch (cost) {
+                case 3:
+                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 30000));
+                    break;
+                case 5:
+                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 50000));
+                    break;
+                case 10:
+                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 100000));
+                    break;
+                case 11:
+                    predicates.add(criteriaBuilder.greaterThan(root.get("cost"), 100000));
+                    break;
+                default:
+                    break;
             }
         }
     }
+
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#136

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 단위가 만단위에서 원단위로 변경했습니다.
- 3,5,10,11일때 들어가는 로직으로 변경
```
    private static void addCostPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<?> root,
                                         Integer cost) {
        if (cost != null) {
            switch (cost) {
                case 3:
                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 30000));
                    break;
                case 5:
                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 50000));
                    break;
                case 10:
                    predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("cost"), 100000));
                    break;
                case 11:
                    predicates.add(criteriaBuilder.greaterThan(root.get("cost"), 100000));
                    break;
                default:
                    break;
            }
        }
    }
```
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #136 