### PR TITLE
[FIX] Date 필터링 조회 리스트 순서 변경 - #152

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
@@ -14,11 +14,13 @@ import java.util.Optional;
 public interface DateRepository extends JpaRepository<Date, Long> {
     Optional<Date> findFirstByUserIdAndDateAfterOrDateAndStartAtAfterOrderByDateAscStartAtAsc(
             Long userId, LocalDate currentDate, LocalDate sameDay, LocalTime currentTime);
-    @Query("select d from Date d where d.user.id = :userId and d.date < :currentDate")
+
+    @Query("select d from Date d where d.user.id = :userId and d.date < :currentDate order by d.date desc")
     List<Date> findPastDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);
 
-    @Query("select d from Date d where d.user.id = :userId and d.date >= :currentDate")
+    @Query("select d from Date d where d.user.id = :userId and d.date >= :currentDate order by d.date asc")
     List<Date> findFutureDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);
+
 }
 
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#152

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
Date 필터링 조회 리스트 순서 변경했습니다. 
기존 pk 순에서
지난 일정은 최신 순, 미래 일정은 현재 날짜와 가까운 순

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #152