### PR TITLE
[FEAT] 유저 탈퇴 시, 관련 데이터 삭제 - #176

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
@@ -1,9 +1,12 @@
 package org.dateroad.date.service;
 
 import org.dateroad.date.domain.Date;
+import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,6 +14,7 @@ import java.util.List;
 import java.time.LocalTime;
 import java.util.Optional;
 
+@Repository
 public interface DateRepository extends JpaRepository<Date, Long> {
     Optional<Date> findFirstByUserIdAndDateAfterOrDateAndStartAtAfterOrderByDateAscStartAtAsc(
             Long userId, LocalDate currentDate, LocalDate sameDay, LocalTime currentTime);
@@ -20,6 +24,10 @@ public interface DateRepository extends JpaRepository<Date, Long> {
 
     @Query("select d from Date d where d.user.id = :userId and d.date >= :currentDate order by d.date asc")
     List<Date> findFutureDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }
 

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -1,7 +1,6 @@
 package org.dateroad.user.service;
 
 import io.micrometer.common.lang.Nullable;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dateroad.code.FailureCode;

--- a/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/date/repository/CourseRepository.java
@@ -25,4 +25,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> , JpaSpeci
     List<Course> findTopCoursesByLikes(Pageable pageable);
     @Query("SELECT c FROM Course c ORDER BY c.createdAt DESC")
     List<Course> findTopCoursesByCreatedAt(Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/dateAccess/repository/DateAccessRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/dateAccess/repository/DateAccessRepository.java
@@ -3,6 +3,7 @@ package org.dateroad.dateAccess.repository;
 import java.util.List;
 import org.dateroad.date.domain.Course;
 import org.dateroad.dateAccess.domain.DateAccess;
+import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +22,8 @@ public interface DateAccessRepository extends JpaRepository<DateAccess,Long> {
     @Transactional
     @Query(value = "DELETE FROM date_access WHERE course_id = :courseId", nativeQuery = true)
     void deleteByCourse(@Param("courseId") Long courseId);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/like/repository/LikeRepository.java
@@ -1,7 +1,6 @@
 package org.dateroad.like.repository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.dateroad.date.domain.Course;
 import org.dateroad.like.domain.Like;
@@ -26,4 +25,8 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query("SELECT l.course, COUNT(l) FROM Like l WHERE l.course IN :courses GROUP BY l.course")
     List<Object[]> countByCourses(@Param("courses") List<Course> courses);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/point/repository/PointRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/point/repository/PointRepository.java
@@ -2,10 +2,18 @@ package org.dateroad.point.repository;
 
 import java.util.List;
 import org.dateroad.point.domain.Point;
+import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PointRepository extends JpaRepository<Point, Long> {
-    List<Point> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Point> findAllByUserIdOrderByCreatedAtDesc(final Long userId);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/tag/repository/UserTagRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/tag/repository/UserTagRepository.java
@@ -1,11 +1,20 @@
 package org.dateroad.tag.repository;
 
 import org.dateroad.tag.domain.UserTag;
+import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface UserTagRepository extends JpaRepository<UserTag, Long> {
-    List<UserTag> findAllByUserId(Long userId);
-    void deleteAllByUserId(Long userId);
+    List<UserTag> findAllByUserId(final Long userId);
+
+    @Modifying
+    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
+    void deleteAllByUserId(@Param("userId") final Long userId);
 }

--- a/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
+++ b/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
@@ -55,8 +55,8 @@ public class User extends BaseTimeEntity {
     @Setter
     private int totalPoint = 0;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    private Set<UserTag> userTags;
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+//    private Set<UserTag> userTags;
 
     public static User create(final String name, final String platformUserId, final Platform platForm, final String imageUrl) {
         return User.builder()

--- a/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
+++ b/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
@@ -55,9 +55,6 @@ public class User extends BaseTimeEntity {
     @Setter
     private int totalPoint = 0;
 
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-//    private Set<UserTag> userTags;
-
     public static User create(final String name, final String platformUserId, final Platform platForm, final String imageUrl) {
         return User.builder()
                 .name(name)

--- a/dateroad-domain/src/main/java/org/dateroad/user/repository/UserRepository.java
+++ b/dateroad-domain/src/main/java/org/dateroad/user/repository/UserRepository.java
@@ -3,9 +3,11 @@ package org.dateroad.user.repository;
 import org.dateroad.user.domain.Platform;
 import org.dateroad.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsUserByPlatFormAndPlatformUserId(final Platform platform, final String platformUserId);
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#176

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 유저 탈퇴 시, 관련 데이터를 다 지워주었습니다.
```java
//유저 탈퇴 시, 모든 유저 정보 삭제
    private void deleteAllDataByUser(final Long userId) {

        //유저태그 삭제
        userTagRepository.deleteAllByUserId(userId);

        //유저포인트 삭제
        pointRepository.deleteAllByUserId(userId);

        //유저데이트 삭제
        dateRepository.deleteAllByUserId(userId);

        //유저 date_access 삭제
        dateAccessRepository.deleteAllByUserId(userId);

        //유저 코스 삭제
        courseRepository.deleteAllByUserId(userId);

        //유저 좋아요 삭제
        likeRepository.deleteAllByUserId(userId);

        //리프레시토큰 삭제
        deleteRefreshToken(userId);

        //유저 삭제
        userRepository.deleteById(userId);
    }
```

- 또한 DeleteAllInBatch를 통해 한번에 지우도록 했습니다
```java
@Modifying
    @Query("DELETE FROM UserTag ut WHERE ut.user.id = :userId")
    void deleteAllByUserId(@Param("userId") final Long userId);
```
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #176