### PR TITLE
[FIX] 가장 가까운 일정 조회 쿼리 수정 - #189

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateRepository.java
@@ -16,8 +16,17 @@ import java.util.Optional;
 
 @Repository
 public interface DateRepository extends JpaRepository<Date, Long> {
-    Optional<Date> findFirstByUserIdAndDateAfterOrDateAndStartAtAfterOrderByDateAscStartAtAsc(
-            Long userId, LocalDate currentDate, LocalDate sameDay, LocalTime currentTime);
+
+    @Query(value = "SELECT * FROM dates d " +
+            "WHERE d.user_id = :userId " +
+            "AND (d.date > :currentDate " +
+            "     OR (d.date = :currentDate AND d.start_at > :currentTime)) " +
+            "ORDER BY d.date ASC, d.start_at ASC " +
+            "LIMIT 1", nativeQuery = true)
+    Optional<Date> findClosestDateByUserIdAndCurrentDate(
+            @Param("userId") Long userId,
+            @Param("currentDate") LocalDate currentDate,
+            @Param("currentTime") LocalTime currentTime);
 
     @Query("select d from Date d where d.user.id = :userId and d.date < :currentDate order by d.date desc")
     List<Date> findPastDatesByUserId(@Param("userId") Long userId, @Param("currentDate") LocalDate currentDate);

--- a/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/service/DateService.java
@@ -163,7 +163,7 @@ public class DateService {
     }
 
     private Date findNearestDate(Long userId, LocalDate currentDate, LocalTime currentTime) {
-        return dateRepository.findFirstByUserIdAndDateAfterOrDateAndStartAtAfterOrderByDateAscStartAtAsc(userId, currentDate, currentDate, currentTime)
+        return dateRepository.findClosestDateByUserIdAndCurrentDate(userId, currentDate, currentTime)
                 .orElseThrow(() -> new EntityNotFoundException(FailureCode.DATE_NOT_FOUND));
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#189

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 가장 가까운 일정 조회 쿼리 수정 
```java
    @Query(value = "SELECT * FROM dates d " +
            "WHERE d.user_id = :userId " +
            "AND (d.date > :currentDate " +
            "     OR (d.date = :currentDate AND d.start_at > :currentTime)) " +
            "ORDER BY d.date ASC, d.start_at ASC " +
            "LIMIT 1", nativeQuery = true)
    Optional<Date> findClosestDateByUserIdAndCurrentDate(
            @Param("userId") Long userId,
            @Param("currentDate") LocalDate currentDate,
            @Param("currentTime") LocalTime currentTime);
```


## 📟 관련 이슈
- Resolved: #189