### PR TITLE
[FIX] 유저 사진 Update 메소드 및 코스 당일 생성 에러 수정 - #227

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateReq.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateReq.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
@@ -35,7 +36,7 @@ public class CourseCreateReq {
     @Schema(description = "데이트 시작 날짜", example = "2024.07.04", pattern = "yyyy.MM.dd", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     @NotNull(message = "시작 날짜는 필수입니다. ex ) \"2024.07.04\",")
-    @Past
+    @PastOrPresent
     private LocalDate date;
 
     @Schema(description = "데이트 시작 시간", example = "12:30 PM", pattern = "hh:mm a", type = "string")

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -55,7 +55,6 @@ public class UserService {
                                 final List<DateTagType> tags,
                                 @Nullable final MultipartFile newImage) {
         User foundUser = findUserById(userId);
-
         //이름 변경
         foundUser.setName(name);
 
@@ -71,17 +70,18 @@ public class UserService {
         if (userImage != null && (newImage == null || newImage.isEmpty())) {
             deleteImage(userImage);
             foundUser.setImageUrl(null);
-
         // 2. 원래 이미지가 있다가 새로운 이미지로 변경
-        }  else if ((userImage != null) && (newImage != null || !newImage.isEmpty())) {
-            deleteImage(userImage);
-            String newImageUrl = getImageUrl(newImage);
-            foundUser.setImageUrl(newImageUrl);
+        }  else {
+            if ((userImage != null)) {
+                deleteImage(userImage);
+                String newImageUrl = getImageUrl(newImage);
+                foundUser.setImageUrl(newImageUrl);
 
-        // 3. 원래 이미지가 없다가 새로운 이미지로 변경
-        } else if (userImage == null && (newImage != null || !newImage.isEmpty())) {
-            String newImageUrl = getImageUrl(newImage);
-            foundUser.setImageUrl(newImageUrl);
+                // 3. 원래 이미지가 없다가 새로운 이미지로 변경
+            } else if (newImage != null && !newImage.isEmpty()) {
+                String newImageUrl = getImageUrl(newImage);
+                foundUser.setImageUrl(newImageUrl);
+            }
         }
         userRepository.save(foundUser);
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#227

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 유저 이미지 수정 API 로직 변ㄴ경
```java
else {
            if ((userImage != null)) {
                deleteImage(userImage);
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);

                // 3. 원래 이미지가 없다가 새로운 이미지로 변경
            } else if (newImage != null && !newImage.isEmpty()) {
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);
            }
        }
```

- 코스등록 유효성 어노테이션 변경
```java
    @NotNull(message = "시작 날짜는 필수입니다. ex ) \"2024.07.04\",")
    @PastOrPresent
    private LocalDate date;
```
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #227 