### PR TITLE
[FIX] 프로필 수정 api 이미지 관련 변경 - #231

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -70,18 +70,17 @@ public class UserService {
         if (userImage != null && (newImage == null || newImage.isEmpty())) {
             deleteImage(userImage);
             foundUser.setImageUrl(null);
-        // 2. 원래 이미지가 있다가 새로운 이미지로 변경
-        }  else {
-            if ((userImage != null)) {
-                deleteImage(userImage);
-                String newImageUrl = getImageUrl(newImage);
-                foundUser.setImageUrl(newImageUrl);
 
-                // 3. 원래 이미지가 없다가 새로운 이미지로 변경
-            } else if (newImage != null && !newImage.isEmpty()) {
+        // 2. 원래 이미지가 있다가 새로운 이미지로 변경
+        } else if (userImage != null && (!newImage.isEmpty() || newImage != null)) {
+            deleteImage(userImage);
+            String newImageUrl = getImageUrl(newImage);
+            foundUser.setImageUrl(newImageUrl);
+
+        // 3. 원래 이미지가 없다가 새로운 이미지로 변경
+        } else if (userImage == null && (!newImage.isEmpty() || newImage != null)){
                 String newImageUrl = getImageUrl(newImage);
                 foundUser.setImageUrl(newImageUrl);
-            }
         }
         userRepository.save(foundUser);
     }

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
         String userImage = foundUser.getImageUrl();
 
         // 1. 원래 이미지가 있다가 null로 변경
-        if (userImage != null && (newImage == null || newImage.isEmpty())) {
+        if (userImage != null && newImage == null) {
             deleteImage(userImage);
             foundUser.setImageUrl(null);
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#231

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 유저 프로필 수정 API 이미지 null 관련 이슈 해결

```java
 // 1. 원래 이미지가 있다가 null로 변경
        if (userImage != null && (newImage == null || newImage.isEmpty())) {
            deleteImage(userImage);
            foundUser.setImageUrl(null);

        // 2. 원래 이미지가 있다가 새로운 이미지로 변경
        } else if (userImage != null && (!newImage.isEmpty() || newImage != null)) {
            deleteImage(userImage);
            String newImageUrl = getImageUrl(newImage);
            foundUser.setImageUrl(newImageUrl);

        // 3. 원래 이미지가 없다가 새로운 이미지로 변경
        } else if (userImage == null && (!newImage.isEmpty() || newImage != null)){
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);
        }
```

## 📟 관련 이슈
- Resolved: #231