### PR TITLE
[FEAT] 단일 Redis -> Cluster Migration - #233

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/config/RedisConfig.java
+++ b/dateroad-api/src/main/java/org/dateroad/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package org.dateroad.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactoryForCluster() {
+        RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration()
+                .clusterNode("127.0.0.1", 7000)
+                .clusterNode("127.0.0.1", 7001)
+                .clusterNode("127.0.0.1", 7002)
+                .clusterNode("127.0.0.1", 7003)
+                .clusterNode("127.0.0.1", 7004)
+                .clusterNode("127.0.0.1", 7005);
+        // 클러스터 모드로 LettuceConnectionFactory 설정
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(clusterConfig);
+        lettuceConnectionFactory.setShareNativeConnection(false); // 클러스터 모드에서 필요에 따라 사용할 수 있음
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setEnableTransactionSupport(true);
+        redisTemplate.setConnectionFactory(redisConnectionFactoryForCluster());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/dateroad-api/src/main/java/org/dateroad/config/RedisStreamConfig.java
+++ b/dateroad-api/src/main/java/org/dateroad/config/RedisStreamConfig.java
@@ -2,6 +2,7 @@ package org.dateroad.config;
 
 
 import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
 import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.output.StatusOutput;
 import io.lettuce.core.protocol.CommandArgs;
@@ -10,13 +11,20 @@ import io.lettuce.core.protocol.CommandType;
 import lombok.RequiredArgsConstructor;
 import org.dateroad.point.event.FreeEventListener;
 import org.dateroad.point.event.PointEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisClusterConnection;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.connection.stream.*;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.stream.StreamMessageListenerContainer;
 import org.springframework.data.redis.stream.Subscription;
@@ -30,56 +38,40 @@ import java.util.Objects;
 public class RedisStreamConfig {
     private final PointEventListener pointEventListener;
     private final FreeEventListener freeEventListener;
-    @Value("${spring.data.redis.host}")
-    private String host;
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-        return redisTemplate;
-    }
-
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
-    }
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public void createStreamConsumerGroup(final String streamKey, final String consumerGroupName) {
-        if (Boolean.FALSE.equals(redisTemplate().hasKey(streamKey))) {
-            RedisAsyncCommands<String, String> commands = (RedisAsyncCommands<String, String>) Objects.requireNonNull(
-                            redisTemplate()
-                                    .getConnectionFactory())
-                    .getConnection()
-                    .getNativeConnection();
+        if (Boolean.FALSE.equals(redisTemplate.hasKey(streamKey))) {
+            // Stream이 존재하지 않을 경우, MKSTREAM 옵션으로 스트림과 그룹을 생성
+            redisTemplate.execute((RedisCallback<Void>) connection -> {
+                if (connection.isPipelined() || connection.isQueueing()) {
+                    throw new UnsupportedOperationException("Pipelined or queued connections are not supported for cluster.");
+                }
+                byte[] streamKeyBytes = streamKey.getBytes();
+                byte[] consumerGroupNameBytes = consumerGroupName.getBytes();
 
-            CommandArgs<String, String> args = new CommandArgs<>(StringCodec.UTF8)
-                    .add(CommandKeyword.CREATE)
-                    .add(streamKey)
-                    .add(consumerGroupName)
-                    .add("0")
-                    .add("MKSTREAM");
-            // MKSTREAM 옵션을 사용하여 스트림과 그룹을 생성
-            commands.dispatch(CommandType.XGROUP, new StatusOutput<>(StringCodec.UTF8), args).toCompletableFuture()
-                    .join();
-        }
-        // Stream 존재 시, ConsumerGroup 존재 여부 확인 후 ConsumerGroup을 생성
-        else {
+                if (connection instanceof RedisClusterConnection clusterConnection) {
+                    // 클러스터 모드에서 명령 실행
+                    clusterConnection.execute("XGROUP", "CREATE".getBytes(), streamKeyBytes, consumerGroupNameBytes, "0".getBytes(), "MKSTREAM".getBytes());
+                } else {
+                    // 비클러스터 모드에서 명령 실행
+                    connection.execute("XGROUP", "CREATE".getBytes(), streamKeyBytes, consumerGroupNameBytes, "0".getBytes(), "MKSTREAM".getBytes());
+                }
+
+                return null;
+            });
+        } else {
+            // Stream이 존재할 경우 ConsumerGroup 존재 여부 확인 후 생성
             if (!isStreamConsumerGroupExist(streamKey, consumerGroupName)) {
-                redisTemplate().opsForStream().createGroup(streamKey, ReadOffset.from("0"), consumerGroupName);
+                redisTemplate.opsForStream().createGroup(streamKey, ReadOffset.from("0"), consumerGroupName);
             }
         }
     }
 
     // ConsumerGroup 존재 여부 확인
     public boolean isStreamConsumerGroupExist(final String streamKey, final String consumerGroupName) {
-        Iterator<StreamInfo.XInfoGroup> iterator = redisTemplate()
+        Iterator<StreamInfo.XInfoGroup> iterator = redisTemplate
                 .opsForStream().groups(streamKey).stream().iterator();
-
         while (iterator.hasNext()) {
             StreamInfo.XInfoGroup xInfoGroup = iterator.next();
             if (xInfoGroup.groupName().equals(consumerGroupName)) {
@@ -90,13 +82,13 @@ public class RedisStreamConfig {
     }
 
     @Bean
-    public Subscription pointSubscription() {
+    public Subscription pointSubscription(RedisConnectionFactory redisConnectionFactoryForCluster) {
         createStreamConsumerGroup("coursePoint", "courseGroup");
         StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> containerOptions = StreamMessageListenerContainer.StreamMessageListenerContainerOptions
                 .builder().pollTimeout(Duration.ofMillis(100)).build();
 
         StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer.create(
-                redisConnectionFactory(),
+                redisConnectionFactoryForCluster,
                 containerOptions);
 
         Subscription subscription = container.receiveAutoAck(Consumer.from("courseGroup", "instance-1"),
@@ -106,12 +98,12 @@ public class RedisStreamConfig {
     }
 
     @Bean
-    public Subscription freeSubscription() {
+    public Subscription freeSubscription(RedisConnectionFactory redisConnectionFactoryForCluster) {
         createStreamConsumerGroup("courseFree", "courseGroup");
         StreamMessageListenerContainer.StreamMessageListenerContainerOptions<String, MapRecord<String, String, String>> containerOptions = StreamMessageListenerContainer.StreamMessageListenerContainerOptions
                 .builder().pollTimeout(Duration.ofMillis(100)).build();
         StreamMessageListenerContainer<String, MapRecord<String, String, String>> container = StreamMessageListenerContainer.create(
-                redisConnectionFactory(),
+                redisConnectionFactoryForCluster,
                 containerOptions);
         Subscription subscription = container.receiveAutoAck(Consumer.from("courseGroup", "instance-2"),
                 StreamOffset.create("courseFree", ReadOffset.lastConsumed()), freeEventListener);
@@ -119,4 +111,3 @@ public class RedisStreamConfig {
         return subscription;
     }
 }
-

--- a/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
@@ -11,6 +11,8 @@ import org.dateroad.course.dto.request.PointUseReq;
 import org.dateroad.course.dto.request.TagCreateReq;
 import org.dateroad.date.domain.Course;
 import org.dateroad.image.domain.Image;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,7 @@ public class AsyncService {
     private final CoursePlaceService coursePlaceService;
     private final CourseTagService courseTagService;
     private final ImageService imageService;
-    private final StringRedisTemplate redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
     public List<Image> createImage(final List<MultipartFile> images, final Course course) {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#233

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
-2가지의 Redis ConnectionFactory를 사용합니다.
   1. ElasticCache Redis와 연결하는 RedisConnectionFactory -> 단일포트연결
   2. Ec2 내부 RedisCluster와 연결하는 RedisConnectionFactory -> 6개 포트 연결
   3. 따라서 그에 따라 For + [ Cache , Cluster ] 로 명명했습니다.

- 각각의 Connection을 통해 RedisTemplate 객체를 통해 알맞는 연결에 따른 객체를 보낼수 있습니다.
- 단일 Redis 연결
- ```java
  public class RedisCacheConfig {

    @Value("${spring.data.redis.host}")
    private String host;
    @Value("${spring.data.redis.port}")
    private int port;

    @Bean
    public RedisConnectionFactory redisConnectionFactoryForCache() {
        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
    }

    @Bean
    public RedisTemplate<String, Object> redisTemplateForCache() {
        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
        redisTemplate.setConnectionFactory(redisConnectionFactoryForCache());
        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(new StringRedisSerializer());
        return redisTemplate;
    }
  ```
- Cluster Redis 연결
```java

    @Configuration
    public class RedisConfig {

    @Bean
    public RedisConnectionFactory redisConnectionFactoryForCluster() {
        RedisClusterConfiguration clusterConfig = new RedisClusterConfiguration()
                .clusterNode("127.0.0.1", 7000)
                .clusterNode("127.0.0.1", 7001)
                .clusterNode("127.0.0.1", 7002)
                .clusterNode("127.0.0.1", 7003)
                .clusterNode("127.0.0.1", 7004)
                .clusterNode("127.0.0.1", 7005);
        // 클러스터 모드로 LettuceConnectionFactory 설정
        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(clusterConfig);
        lettuceConnectionFactory.setShareNativeConnection(false); // 클러스터 모드에서 필요에 따라 사용할 수 있음
        return lettuceConnectionFactory;
    }

    @Bean
    public RedisTemplate<String, Object> redisTemplate() {
        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
        redisTemplate.setEnableTransactionSupport(true);
        redisTemplate.setConnectionFactory(redisConnectionFactoryForCluster());
        redisTemplate.setKeySerializer(new StringRedisSerializer());
        redisTemplate.setValueSerializer(new StringRedisSerializer());
        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
        return redisTemplate;
    }

 }
 ```


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- EC2 내부 변경파일
- deploy.sh : 기존 spring은 그대로 + cluster 생성로직 추가
- redis_conf : redis 설정파일 

## 📟 관련 이슈
- Resolved: #233 