### PR TITLE
[FEAT] 프로필 수정 API 필드 추가 - #239

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/api/UserApi.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/api/UserApi.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "유저 관련 API")
@@ -143,7 +144,8 @@ public interface UserApi {
             @UserId final Long userId,
             @RequestPart("name") final String name,
             @RequestPart("tags") final List<DateTagType> tags,
-            @RequestPart("image") final MultipartFile image)
+            @RequestPart("image") final MultipartFile image,
+            @RequestPart("isDefaultImage") final boolean isDefaultImage)
             throws IOException, ExecutionException, InterruptedException;
 
 }

--- a/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/api/UserController.java
@@ -87,8 +87,9 @@ public class UserController implements UserApi {
     public ResponseEntity<Void> patchUserProfile(@UserId final Long userId,
                                                  @RequestPart("name") final String name,
                                                  @RequestPart("tags") final List<DateTagType> tags,
-                                                 @Nullable @RequestPart(name = "image", required = false) final MultipartFile image ) throws IOException, ExecutionException, InterruptedException {
-        userService.editUserProfile(userId, name, tags, image);
+                                                 @Nullable @RequestPart(name = "image", required = false) final MultipartFile image,
+                                                 @RequestPart("isDefaultImage") final boolean isDefaultImage ) {
+        userService.editUserProfile(userId, name, tags, image, isDefaultImage);
         return ResponseEntity
                 .ok()
                 .build();

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -68,36 +68,28 @@ public class UserService {
         boolean isNewImageEmpty = newImage.isEmpty() || newImage == null;
         String userImage = foundUser.getImageUrl();
 
-        // 1. 원래 이미지가 있다가 기본 이미지로 변경( A -> 기본 이미지)
-            // 아요 : null, isDefaultImage(T)
-            // 안드 : null, isDefaultImage(T)
-        if (userImage != null && isNewImageEmpty && isDefaultImage) {
-            deleteImage(userImage);
-            foundUser.setImageUrl(null);
-            userRepository.save(foundUser);
-
-        // 2. 원래 이미지가 있다가 다른 새로운 이미지로 변경되거나 원래 이미지 그대로 (A -> B or A -> A)
-            // 아요 : new imageUrl or imageUrl, isDefaultImage(F)
-            // 안드 : new imageUrl or null, isDefaultImage(F)
-        } else if (userImage != null && !isDefaultImage) {
-
-            // 아요 : 원래 이미지 그대로일수도 있고, 새로운 이미지일수도 있음
-            // 안드 : 새로운 이미지
-            if(!isNewImageEmpty) {
+        // 기본이미지로 변경
+        if(isNewImageEmpty && isDefaultImage) {
+            //원래 이미지가 기본 이미지가 아닐 경우
+            if(userImage != null) {
                 deleteImage(userImage);
-                String newImageUrl = getImageUrl(newImage);
-                foundUser.setImageUrl(newImageUrl);
             }
-            userRepository.save(foundUser);
+            foundUser.setImageUrl(null);
 
-        // 3. 기본이미지에서 새로운 이미지로 변경 (기본 이미지 -> A)
-        } else if (userImage == null && !isNewImageEmpty && !isDefaultImage){
-                String newImageUrl = getImageUrl(newImage);
-                foundUser.setImageUrl(newImageUrl);
-            userRepository.save(foundUser);
+        // 원래 이미지를 그대로 사용하거나, 새로운 이미지로 변경
+        } else if(!isDefaultImage) {
+
+            // 아요 : 이게 원래 사진 그대로 사용했거나, 새로운 사진으로 변경
+            // 안드 : 원래 이미지에서 새로운 이미지
+            if(userImage != null && !isNewImageEmpty) {
+                deleteImage(userImage);
+            }
+            String newImageUrl = getImageUrl(newImage);
+            foundUser.setImageUrl(newImageUrl);
         } else {
             throw new BadRequestException(FailureCode.INVALID_IMAGE_EDIT);
         }
+        userRepository.save(foundUser);
     }
 
     public UserInfoMainRes getUserInfoMain(final Long userId) {

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -26,6 +26,7 @@ public enum FailureCode {
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "e4102", "필드가 잘못되었습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "e4103", "잘못된 필드를 넣었습니다."),
     INVALID_DISCORD_SIGNUP_MESSAGE(HttpStatus.BAD_REQUEST, "e4104", "회원가입 디스코드 알림 전송에 실패하였습니다."),
+    INVALID_IMAGE_EDIT(HttpStatus.BAD_REQUEST, "e4105", "프로필 이미지 수정에 실패하였습니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#239

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### 1. 프로필 수정 API request body 필드 추가
안드와 iOS 파트의 이미지 관련 구현 방식의 차이가 약간 있어서 이미지 수정 관련 필드를 하나 추가하였습니다.

현재 iOS와 안드로이드 이미지 관련 구현 차이점
- iOS : 원래 유저 이미지에서 같은 유저 이미지로 수정할 때(즉 원래의 이미지를 유저가 사용할 때), 다시 이미지 url을 보내줌
- 안드 : 원래 유저 이미지에서 같은 유저 이미지로 수정할 때(즉 원래의 이미지를 유저가 사용할 때), null을 보내줌

안드의 경우, 현재 유저가 기본 프로필 이미지로 변경해서 null을 보내주는 것인지, 원래 자신의 프로필 이미지를 그대로 사용해서 null을 보내주는 것인지 서버에서 판단이 불가함

그래서 아래와 같이 경우의 수를 나누었습니다.
- 기본 -> 기본
  -  필드값  T
  - 아요 : null
  - 안드 : null

- A -> 기본 
  - 필드값 T
  - 아요 : null
  - 안드 : null

- 기본 -> A 
  - 필드값 F
  - 아요 : 멀티파트
  - 안드 : 멀티파트

- A -> A 
  - 필드값 F
  - 아요 : 멀티파트
  - 안드 : null

- A -> B
  - 필드값 F
  - 아요 : 멀티파트
  - 안드 : 멀티파트

클라에서 수정되는 부분이 기본사진인지 아닌지를 판별해주면 됩니다.



### 2. 구현 코드
```java
//이미지 변경
        boolean isNewImageEmpty = newImage.isEmpty() || newImage == null;
        String userImage = foundUser.getImageUrl();

        // 1. 원래 이미지가 있다가 기본 이미지로 변경( A -> 기본 이미지)
            // 아요 : null, isDefaultImage(T)
            // 안드 : null, isDefaultImage(T)
        if (userImage != null && isNewImageEmpty && isDefaultImage) {
            deleteImage(userImage);
            foundUser.setImageUrl(null);
            userRepository.save(foundUser);

        // 2. 원래 이미지가 있다가 다른 새로운 이미지로 변경되거나 원래 이미지 그대로 (A -> B or A -> A)
            // 아요 : new imageUrl or imageUrl, isDefaultImage(F)
            // 안드 : new imageUrl or null, isDefaultImage(F)
        } else if (userImage != null && !isDefaultImage) {

            // 아요 : 원래 이미지 그대로일수도 있고, 새로운 이미지일수도 있음
            // 안드 : 새로운 이미지
            if(!isNewImageEmpty) {
                deleteImage(userImage);
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);
            }
            userRepository.save(foundUser);

        // 3. 기본이미지에서 새로운 이미지로 변경 (기본 이미지 -> A)
        } else if (userImage == null && !isNewImageEmpty && !isDefaultImage){
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);
            userRepository.save(foundUser);
        } else {
            throw new BadRequestException(FailureCode.INVALID_IMAGE_EDIT);
        }
```

- 2번 경우의 수에서, 안드의 경우 만약 null을 보내주면 원래 이미지를 그대로 사용한다는 것이기 때문에 따로 다른 액션을 취해주지 않았습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 안드와 iOS 파트의 이미지 관련 구현 방식의 차이가 약간 있어서, 현재 릴리즈 단계에서는 우선 클라이언트에 맞추고, 릴리즈 후에 협의하여 한 가지 방향성으로 맞추기로 함
## 📟 관련 이슈
- Resolved: #239