### PR TITLE
[FEAT] 로컬 환경 구축 Redis Cluster shell 파일 및 Docker compose 구현 - #241

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM amd64/amazoncorretto:21
 COPY dateroad-api/build/libs/dateroad-api-0.0.1-SNAPSHOT.jar dateroad.jar
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=dev", "dateroad.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "-jar", "dateroad.jar"]

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,4 +1,24 @@
 services:
+  database:
+    container_name: database
+    image: postgres
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=0319
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    container_name: redis
+    image: redis
+    expose:
+      - 6379
+    ports:
+      - 6379:6379
+
   redis-master-1:
     container_name: redis-master-1
     image: redis
@@ -110,10 +130,8 @@ services:
   redis-cluster-entry:
     image: redis
     container_name: redis-cluster-entry
-    command:
-      "
+    command: >
       redis-cli --cluster create redis-master-1:7000 redis-master-2:7001 redis-master-3:7002 redis-slave-1:7003 redis-slave-2:7004 redis-slave-3:7005 --cluster-replicas 1 --cluster-yes
-      "
     depends_on:
       - redis-master-1
       - redis-master-2
@@ -123,6 +141,9 @@ services:
       - redis-slave-3
     networks:
       - redis-cluster
+
+volumes:
+  pgdata:
 
 networks:
   redis-cluster:

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,129 @@
+services:
+  redis-master-1:
+    container_name: redis-master-1
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-master-1.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7000:7000
+      - 17000:17000
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-master-2:
+    container_name: redis-master-2
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-master-2.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7001:7001
+      - 17001:17001
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-master-3:
+    container_name: redis-master-3
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-master-3.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7002:7002
+      - 17002:17002
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-slave-1:
+    container_name: redis-slave-1
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-slave-1.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7003:7003
+      - 17003:17003
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-slave-2:
+    container_name: redis-slave-2
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-slave-2.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7004:7004
+      - 17004:17004
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-slave-3:
+    container_name: redis-slave-3
+    image: redis
+    command: redis-server /etc/redis.conf
+    volumes:
+      - ./redis_conf/redis-slave-3.conf:/etc/redis.conf
+    restart: always
+    ports:
+      - 7005:7005
+      - 17005:17005
+    networks:
+      - redis-cluster
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis-cluster-entry:
+    image: redis
+    container_name: redis-cluster-entry
+    command:
+      "
+      redis-cli --cluster create redis-master-1:7000 redis-master-2:7001 redis-master-3:7002 redis-slave-1:7003 redis-slave-2:7004 redis-slave-3:7005 --cluster-replicas 1 --cluster-yes
+      "
+    depends_on:
+      - redis-master-1
+      - redis-master-2
+      - redis-master-3
+      - redis-slave-1
+      - redis-slave-2
+      - redis-slave-3
+    networks:
+      - redis-cluster
+
+networks:
+  redis-cluster:
+    driver: bridge

--- a/redis-cluster-remove.sh
+++ b/redis-cluster-remove.sh
@@ -1,0 +1,1 @@
+docker compose -f docker-compose-redis.yml down

--- a/redis-cluster.sh
+++ b/redis-cluster.sh
@@ -49,7 +49,7 @@ EOL
 done
 
 # Docker Compose로 Redis 노드들을 백그라운드에서 실행
-docker compose -f docker-compose-local.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3
+docker compose -f docker-compose-local.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3 database redis
 echo "REDIS IP : ${REDIS_IP}"
 
 # 모든 노드들이 완전히 실행될 때까지 대기

--- a/redis-cluster.sh
+++ b/redis-cluster.sh
@@ -49,13 +49,11 @@ EOL
 done
 
 # Docker Compose로 Redis 노드들을 백그라운드에서 실행
-docker compose -f docker-compose-redis.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3
+docker compose -f docker-compose-local.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3
 echo "REDIS IP : ${REDIS_IP}"
 
 # 모든 노드들이 완전히 실행될 때까지 대기
 echo "Waiting for Redis nodes to be ready..."
-sleep 5  # 필요시 대기 시간을 조정하세요.
-
 # 클러스터 구성 명령어 실행
 docker exec -it redis-master-1 redis-cli --cluster create \
   redis-master-1:7000 \

--- a/redis-cluster.sh
+++ b/redis-cluster.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# 현재 IP 주소 가져오기
+REDIS_IP=$(hostname -I | awk '{print $1}')
+
+# 환경변수 설정
+export REDIS_IP
+
+# Redis 설정 파일을 저장할 디렉토리 생성
+mkdir -p redis_conf
+
+# 포트 번호 배열 설정
+master_ports=(7000 7001 7002)
+slave_ports=(7003 7004 7005)
+master_types=("master" "master" "master")
+slave_types=("slave" "slave" "slave")
+
+# 각 Redis 노드에 대한 설정 파일 생성
+for i in "${!master_ports[@]}"; do
+  cat <<EOL > redis_conf/redis-${master_types[$i]}-$((i + 1)).conf
+port ${master_ports[$i]}
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 3000
+appendonly yes
+# requirepass xxxx
+protected-mode no
+bind 0.0.0.0
+cluster-announce-ip ${REDIS_IP}
+cluster-announce-port ${master_ports[$i]}
+cluster-announce-bus-port $((17000 + ${master_ports[$i]} - 7000))
+EOL
+done
+
+for i in "${!slave_ports[@]}"; do
+  cat <<EOL > redis_conf/redis-${slave_types[$i]}-$((i + 1)).conf
+port ${slave_ports[$i]}
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 3000
+appendonly yes
+# requirepass xxxx
+protected-mode no
+bind 0.0.0.0
+cluster-announce-ip ${REDIS_IP}
+cluster-announce-port ${slave_ports[$i]}
+cluster-announce-bus-port $((17000 + ${slave_ports[$i]} - 7000))
+EOL
+done
+
+# Docker Compose로 Redis 노드들을 백그라운드에서 실행
+docker compose -f docker-compose-redis.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3
+echo "REDIS IP : ${REDIS_IP}"
+
+# 모든 노드들이 완전히 실행될 때까지 대기
+echo "Waiting for Redis nodes to be ready..."
+sleep 5  # 필요시 대기 시간을 조정하세요.
+
+# 클러스터 구성 명령어 실행
+docker exec -it redis-master-1 redis-cli --cluster create \
+  redis-master-1:7000 \
+  redis-master-2:7001 \
+  redis-master-3:7002 \
+  redis-slave-1:7003 \
+  redis-slave-2:7004 \
+  redis-slave-3:7005 \
+  --cluster-replicas 1 --cluster-yes
+
+# 성공 메시지 출력
+echo "Redis cluster has been created successfully."


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#241

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
Docker compose를 활용한 Redis cluster로컬 구축
- 가든이가 세세하게 써달라고해서 작성해주는 기초부터 시작하는 Docker~!
## Docker compose란 ?
- 도커 컨테이너를 여러개 관리할수 있는 Tool!입니다. 
다른 관리 Tool로는 유명한 k8s==쿠버네티스가 있죠? 
ec2의 프리티어에는 k8s돌리면 터지기 때문에 이렇게 간단하게 관리할수 있는 docker compose를 사용하겠습니다~!

- Example로 Master 1개 노드만 보겠습니다!
```yml 
services:
  // docker 컨테이너 구동 이름!
  redis-master-1:
    container_name: redis-master-1
     // 사용할 이미지! 
    image: redis
     // 컨테이너 구동후 ! 명령어! -> redis-server를 통해 redis.conf파일을
     // 노드의 설정기본값으로 세팅합니다! conf.예시는 아래에 적어놓을게요~
    command: redis-server /etc/redis.conf
    // Docker가 로컬 머신과 공유하는 메모리 위치! 컨테이너와 내 메모리가 연결돼요~
    volumes:
      - ./redis_conf/redis-master-1.conf:/etc/redis.conf
     // 노드 특성상 마비가 생기면 꺼질수 있기 때문에 자동으로 감지해서 켜줍니다~!
     //하지만 자동으로 꺼졋다 키는건 k8s가 더좋다고 합니다 
     //프로젝트의 크기가 작으니 docker-compose로 관리합니다!
    restart: always
     // 포트를 2개 뜰어주는 이유는? cluster port + cluster bus port
     // cluster 구성시 각 포트끼리 연결되지만 장애감지, 구성업데이트
     // failover(노드가 장애발생시에) 다른 노드를 master노드로 승격시킬수있는 포트를 추가로 열어주어야합니다! 
    ports:
      //접속 포트
      - 7000:7000
      //cluster bus 포트 
      - 17000:17000
    networks:
      // 도커컨테이너간의 통신을 위해서 redis-cluster로 네트워크를 만들어줍니다.
      // 사실 없어도되는부분같아요 !
      - redis-cluster
     // 그냥 상태감지입니다.
    healthcheck:
      test: ["CMD", "redis-cli", "ping"]
      interval: 10s
      timeout: 5s
      retries: 5
```
- redis-cluster-remove.sh
```
docker compose -f docker-compose-redis.yml down
// -f 옵션 : 다음 파일을 사용해라
// down : 도커컴포즈에 있는 모든것들 down : 제거 및 중지
```

- redis-cluster.sh
```
#!/bin/bash

# 현재 IP 주소 가져오기
REDIS_IP=$(hostname -I | awk '{print $1}')

# 환경변수 설정
export REDIS_IP

# Redis 설정 파일을 저장할 디렉토리 생성
mkdir -p redis_conf

# 포트 번호 배열 설정
master_ports=(7000 7001 7002)
slave_ports=(7003 7004 7005)
master_types=("master" "master" "master")
slave_types=("slave" "slave" "slave")

# 각 Redis 노드에 대한 설정 파일 생성
for i in "${!master_ports[@]}"; do
  cat <<EOL > redis_conf/redis-${master_types[$i]}-$((i + 1)).conf
port ${master_ports[$i]}
cluster-enabled yes
cluster-config-file nodes.conf
cluster-node-timeout 3000
appendonly yes
# requirepass xxxx
protected-mode no
bind 0.0.0.0
cluster-announce-ip ${REDIS_IP}
cluster-announce-port ${master_ports[$i]}
cluster-announce-bus-port $((17000 + ${master_ports[$i]} - 7000))
EOL
done

```
- 이부분이 redis 각노드에 설정인 부분입니다.
   - 포트
   - cluster로 작동시킬건지?
   - node timeout 시간 설정
   - appendonly는 redis의 특성상 appendonly를 통해 영구저장하는 속성(인메모리데이터베이스이지만 영구저장하는 속성을 사용할수 있음 : AOF 이라고 주로 함 , 
   Append Only File 
   - cluster-announce-ip : 현재 노드가 동작하는 ip주소 : 자신의 ip주소임
   - cluster-announce-port : 클러스터에게 알려주는 자신의 port
   - cluser-announce-bus-port : 클러스터에게 여러가지 다른 정보들 전달할 주소
```
port ${slave_ports[$i]}
cluster-enabled yes
cluster-config-file nodes.conf
cluster-node-timeout 3000
appendonly yes
# requirepass xxxx
protected-mode no
bind 0.0.0.0
cluster-announce-ip ${REDIS_IP}
cluster-announce-port ${slave_ports[$i]}
cluster-announce-bus-port $((17000 + ${slave_ports[$i]} - 7000))
```

- 그리고 다음 명령어로 노드6개를 실행합니다.
```
docker compose -f docker-compose-redis.yml up -d redis-master-1 redis-master-2 redis-master-3 redis-slave-1 redis-slave-2 redis-slave-3 
```

- 그다음 명령어로 노드 내부로 들어가 각 노드들을 연결해주는 명령어를 실행합니다.
```
 docker exec -it redis-master-1 redis-cli --cluster create \
  redis-master-1:7000 \
  redis-master-2:7001 \
  redis-master-3:7002 \
  redis-slave-1:7003 \
  redis-slave-2:7004 \
  redis-slave-3:7005 \
  --cluster-replicas 1 --cluster-yes 
```

# 사용법!
- 이전에 먼저 실행파일로 만들어주세요~ : 
```
chmod +x redis-cluster.sh redis-cluster-remove.sh
```

- Redis cluster 실행
```
  ./redis-cluster.sh
```

- Redis cluster 끄기
```
 ./redis-cluster-remove.sh
```

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
참고 application.yml 로컬 파일을 aws.ip 이거 localhost로 넣어주세요~

기존에 6379포트로 사용하던 redis도 함께 돌리셔야합니다!~
## 📟 관련 이슈
- Resolved: #241 