### PR TITLE
[FIX] 프로필 수정 API 유저 중복검증 로직 추가 - #243

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
@@ -92,9 +92,7 @@ public class AuthService {
         return UserJwtInfoRes.of(userId, newToken.accessToken(), newToken.refreshToken());
     }
 
-    @Transactional
     public void withdraw(final Long userId, final AppleWithdrawAuthCodeReq AppleWithdrawAuthCodeReq) {
-
         User foundUser = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         if (foundUser.getPlatForm() == Platform.KAKAO) {    //카카오 유저면 카카오와 연결 끊기
             kakaoFeignProvider.unLinkWithKakao(foundUser.getPlatformUserId());
@@ -190,7 +188,8 @@ public class AuthService {
 
     //todo: 추후에 유저 탈퇴 시, 삭제 정보 정해지면 삭제 추가 구현
     //유저 탈퇴 시, 유저 관련 데이터만 삭제
-    private void deleteAllDataByUser(final User user) {
+    @Transactional
+    protected void deleteAllDataByUser(final User user) {
 
         //유저태그 삭제
         userTagRepository.deleteAllByUserId(user.getId());
@@ -220,7 +219,6 @@ public class AuthService {
 
         user.setPlatformUserId("USER DELETED");
         user.setName("삭제된유저");
-
         //유저 삭제
 //        userRepository.deleteById(userId);
 //        user.setDeleted(true);

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dateroad.code.FailureCode;
 import org.dateroad.exception.BadRequestException;
+import org.dateroad.exception.ConflictException;
 import org.dateroad.exception.EntityNotFoundException;
 import org.dateroad.s3.S3Service;
 import org.dateroad.tag.domain.DateTagType;
@@ -57,6 +58,7 @@ public class UserService {
                                 final boolean isDefaultImage) {
         User foundUser = findUserById(userId);
         //이름 변경
+        checkDuplicateNickname(name, foundUser);
         foundUser.setName(name);
 
         //tag 변경
@@ -128,6 +130,15 @@ public class UserService {
         } catch (InterruptedException | ExecutionException | IOException e) {
             log.error(e.getMessage());
             throw new BadRequestException(FailureCode.WRONG_IMAGE_URL);
+        }
+    }
+
+    //닉네임 중복체크
+    private void checkDuplicateNickname(final String nickname, final User foundUser) {
+        if (userRepository.existsByName(nickname)) {
+            if(!foundUser.getName().equals(nickname)) {
+                throw new ConflictException(FailureCode.DUPLICATE_NICKNAME);
+            }
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#243

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 프로필 수정 API 유저 중복검증 로직 추가
자신의 이름으로 그대로 바꾸는 경우도 있기 때문에, 아래와 같이 바꾸었습니다.
```java
 //이름 변경
        checkDuplicateNickname(name, foundUser);
        foundUser.setName(name);
        
            //닉네임 중복체크
    private void checkDuplicateNickname(final String nickname, final User foundUser) {
        if (userRepository.existsByName(nickname)) {
            if(!foundUser.getName().equals(nickname)) {
                throw new ConflictException(FailureCode.DUPLICATE_NICKNAME);
            }
        }
    }
```

## 📟 관련 이슈
- Resolved: #243