### PR TITLE
[FIX] 멀티파트 Null 이슈 해결-  #245

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -65,11 +65,11 @@ public class UserService {
         saveUserTag(foundUser, tags);
 
         //이미지 변경
-        boolean isNewImageEmpty = newImage.isEmpty() || newImage == null;
+        boolean isNewImageNull = newImage == null;
         String userImage = foundUser.getImageUrl();
 
         // 기본이미지로 변경
-        if(isNewImageEmpty && isDefaultImage) {
+        if(isNewImageNull && isDefaultImage) {
             //원래 이미지가 기본 이미지가 아닐 경우
             if(userImage != null) {
                 deleteImage(userImage);
@@ -81,7 +81,7 @@ public class UserService {
 
             // 아요 : 이게 원래 사진 그대로 사용했거나, 새로운 사진으로 변경
             // 안드 : 원래 이미지에서 새로운 이미지
-            if(userImage != null && !isNewImageEmpty) {
+            if(userImage != null && !isNewImageNull) {
                 deleteImage(userImage);
             }
             String newImageUrl = getImageUrl(newImage);


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#245

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
### 멀티파트 null 관련 이슈 해결
현재는 Null과 isEmpty를 같이 체크하고 있었는데, 이렇게 될 경우 클라에서 null을 주면 아래와 같은 에러가 떴다.
"org.springframework.web.multipart.MultipartFile.isEmpty()" because "newImage" is null"}

그래서 클라에서 기본프로필을 주거나 원래 이미지를 그대로 사용할 때 null을 주기로 해서 멀티파트가 null인지만 확인하기로 했다.
```java
 //이미지 변경
        boolean isNewImageNull = newImage == null;
        String userImage = foundUser.getImageUrl();

        // 기본이미지로 변경
        if(isNewImageNull && isDefaultImage) {
            //원래 이미지가 기본 이미지가 아닐 경우
            if(userImage != null) {
                deleteImage(userImage);
            }
            foundUser.setImageUrl(null);

        // 원래 이미지를 그대로 사용하거나, 새로운 이미지로 변경
        } else if(!isDefaultImage) {

            // 아요 : 이게 원래 사진 그대로 사용했거나, 새로운 사진으로 변경
            // 안드 : 원래 이미지에서 새로운 이미지
            if(userImage != null && !isNewImageNull) {
                deleteImage(userImage);
            }
            String newImageUrl = getImageUrl(newImage);
            foundUser.setImageUrl(newImageUrl);
        } else {
            throw new BadRequestException(FailureCode.INVALID_IMAGE_EDIT);
        }
```


## 📟 관련 이슈
- Resolved: #245