### PR TITLE
[FIX] 탈퇴하기 버그 픽스 - #251

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
@@ -189,7 +189,6 @@ public class AuthService {
 
     //todo: 추후에 유저 탈퇴 시, 삭제 정보 정해지면 삭제 추가 구현
     //유저 탈퇴 시, 유저 관련 데이터만 삭제
-    @Transactional
     protected void deleteAllDataByUser(final User user) {
 
         //유저태그 삭제

--- a/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
@@ -92,6 +92,7 @@ public class AuthService {
         return UserJwtInfoRes.of(userId, newToken.accessToken(), newToken.refreshToken());
     }
 
+    @Transactional
     public void withdraw(final Long userId, final AppleWithdrawAuthCodeReq AppleWithdrawAuthCodeReq) {
         User foundUser = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         if (foundUser.getPlatForm() == Platform.KAKAO) {    //카카오 유저면 카카오와 연결 끊기


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#251
👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- @Transactional 어노테이션 버그 
```java
@Transactional
    public void withdraw(final Long userId, final AppleWithdrawAuthCodeReq AppleWithdrawAuthCodeReq) {
        User foundUser = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
        if (foundUser.getPlatForm() == Platform.KAKAO) {    //카카오 유저면 카카오와 연결 끊기
            kakaoFeignProvider.unLinkWithKakao(foundUser.getPlatformUserId());
        } else if (foundUser.getPlatForm() == Platform.APPLE) {    //애플 유저면 애플이랑 연결 끊기
            appleFeignProvider.revokeUser(AppleWithdrawAuthCodeReq.authCode());
        } else {
            throw new InvalidValueException(FailureCode.INVALID_PLATFORM_TYPE);
        }
        deleteAllDataByUser(foundUser);
    }
```
고민인게, 현재 위 메서드가 있는 AuthService 클래스 상단에 @Transactional(readOnly = true)가 있습니다.
그래서 안에 있는 메서드인 withdraw에 @Transactionl을 붙이지 않았더니 reaonly error가 떴습니다.
하지만 탈퇴과정에 feign 통신이 있기때문에, 안쪽 repository에 transactionl을 붙이고 싶은데, 추후에 테스트 해보겠습니다.





## 📟 관련 이슈
- Resolved: #251 