### PR TITLE
[FIX] 프로필 수정 API 버그 픽스 - #258

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -85,9 +85,11 @@ public class UserService {
             // 안드 : 원래 이미지에서 새로운 이미지
             if(userImage != null && !isNewImageNull) {
                 deleteImage(userImage);
+                String newImageUrl = getImageUrl(newImage);
+                foundUser.setImageUrl(newImageUrl);
             }
-            String newImageUrl = getImageUrl(newImage);
-            foundUser.setImageUrl(newImageUrl);
+
+            //안드에서 원래 이미지를 그대로 사용하면 굳이 뭐를 안해도됨
         } else {
             throw new BadRequestException(FailureCode.INVALID_IMAGE_EDIT);
         }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#258

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 안드에서 원래 프로필 이미지를 그대로 사용할 경우의 버그 픽스

```java
       // 기본이미지로 변경
        if(isNewImageNull && isDefaultImage) {
            //원래 이미지가 기본 이미지가 아닐 경우
            if(userImage != null) {
                deleteImage(userImage);
            }
            foundUser.setImageUrl(null);

        // 원래 이미지를 그대로 사용하거나, 새로운 이미지로 변경
        } else if(!isDefaultImage) {

            // 아요 : 이게 원래 사진 그대로 사용했거나, 새로운 사진으로 변경
            // 안드 : 원래 이미지에서 새로운 이미지
            if(userImage != null && !isNewImageNull) {
                deleteImage(userImage);
                String newImageUrl = getImageUrl(newImage);
                foundUser.setImageUrl(newImageUrl);
            }

            //안드에서 원래 이미지를 그대로 사용하면 굳이 뭐를 안해도됨
        }
```

## 📟 관련 이슈
- Resolved: #258