### PR TITLE
[FIX] User 캐시화로 인한 Point 내역조회 수정 - #269

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateEvent.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateEvent.java
@@ -15,16 +15,14 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CourseCreateEvent{
     private Course course;
-    private Long userId;
     private List<CoursePlaceGetReq> places;
     private List<TagCreateReq> tags;
 
-    public static CourseCreateEvent of(Course course, Long userId,
+    public static CourseCreateEvent of(Course course,
                               List<CoursePlaceGetReq> places,
                               List<TagCreateReq> tags) {
         return CourseCreateEvent.builder()
                 .course(course)
-                .userId(userId)
                 .places(places)
                 .tags(tags)
                 .build();

--- a/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/AsyncService.java
@@ -16,7 +16,6 @@ import org.dateroad.course.dto.request.PointUseReq;
 import org.dateroad.course.dto.request.TagCreateReq;
 import org.dateroad.date.domain.Course;
 import org.dateroad.image.domain.Image;
-import org.dateroad.point.domain.TransactionType;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,7 +59,7 @@ public class AsyncService {
 
     @Transactional
     public void runAsyncTasks(List<CoursePlaceGetReq> places, List<TagCreateReq> tags,
-                                Course saveCourse, Long userId)
+                                Course saveCourse)
             throws InterruptedException {
         List<Thread> threads = new ArrayList<>();
         final boolean[] hasError = {false};  // 에러 발생 여부 확인

--- a/dateroad-api/src/main/java/org/dateroad/point/event/PointEventListener.java
+++ b/dateroad-api/src/main/java/org/dateroad/point/event/PointEventListener.java
@@ -1,11 +1,10 @@
 package org.dateroad.point.event;
 
-import java.util.EventListener;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dateroad.code.FailureCode;
-import org.dateroad.course.dto.request.PointUseReq;
 import org.dateroad.exception.DateRoadException;
 import org.dateroad.exception.EntityNotFoundException;
 import org.dateroad.exception.UnauthorizedException;
@@ -14,28 +13,33 @@ import org.dateroad.point.domain.TransactionType;
 import org.dateroad.point.repository.PointRepository;
 import org.dateroad.user.domain.User;
 import org.dateroad.user.repository.UserRepository;
+import org.dateroad.user.service.UserService;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.stream.StreamListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class PointEventListener implements StreamListener<String, MapRecord<String,String,String>>, EventListener {
-    private final UserRepository userRepository;
+@Slf4j
+public class PointEventListener implements StreamListener<String, MapRecord<String,String,String>> {
+    private final UserService userService;
     private final PointRepository pointRepository;
 
     @Override
+    @CacheEvict(cacheNames = "user", key = "#message.id", cacheManager = "cacheManagerForOne")
     @Transactional
     public void onMessage(final MapRecord<String, String, String> message) throws DateRoadException {
         try {
             Map<String, String> map = message.getValue();
             Long userId = Long.valueOf(map.get("userId"));
             TransactionType type = TransactionType.valueOf(map.get("type"));
-            User user = getUser(userId);
+            User user = userService.getUser(userId);
             int point = Integer.parseInt(map.get("point"));
             String description = map.get("description");
+            int beforePoint  = user.getTotalPoint();
             switch (type) {
                 case POINT_GAINED:
                     user.setTotalPoint(user.getTotalPoint() + point);
@@ -47,15 +51,11 @@ public class PointEventListener implements StreamListener<String, MapRecord<Stri
                     throw new UnauthorizedException(FailureCode.INVALID_TRANSACTION_TYPE);
             }
             pointRepository.save(Point.create(user, point, type, description));
-            userRepository.save(user);
+            userService.saveUser(user);
+            log.info("Redis onMessage[POINT]:{}:{}:BEFORE:{} => AFTER:{}", user.getId(),type.getDescription(),beforePoint,user.getTotalPoint());
         } catch (Exception e) {
+            log.error("redis Listener Error:ERROR: {}", e.getMessage());
             throw new DateRoadException(FailureCode.POINT_CREATE_ERROR);
         }
-    }
-
-    private User getUser(Long userId) {
-        return userRepository.findById(userId).orElseThrow(
-                () -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND)
-        );
     }
 }

--- a/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/UserService.java
@@ -116,4 +116,15 @@ public class UserService {
             }
         }
     }
+
+    @CachePut(cacheNames = "user", key = "#user.id", unless = "#result == null", cacheManager = "cacheManagerForOne")
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
+    public User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND)
+        );
+    }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#269

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
# User 캐시화로 인한 Point 내역조회 수정
- User의 save의 경우 cache를 userId를 key값으로 update하도록 조정
```
@CachePut(cacheNames = "user", key = "#user.id", unless = "#result == null", cacheManager = "cacheManagerForOne")
    public User saveUser(User user) {
        return userRepository.save(user);
    }
```
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #269 