### PR TITLE
[FIX] Course 삭제 오류 해결 - #277

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ dateroad-api/src/test/resources/application.yml
 
 ### File ###
 **/static/*.p8
+
+### Redis Config ###
+redis_conf/

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -76,7 +76,7 @@ public enum FailureCode {
     COURSE_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "e40410", "데이트 태그를 찾을 수 없습니다."),
     NEAREST_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40411", "다가오는 데이트를 찾을 수 없습니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "e40412", "해당 데이트 코스에 좋아요를 찾을 수 없습니다."),
-    COURSE_DELETE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "e40414", "해당 코스를 삭제할수 없습니다."),
+    COURSE_DELETE_ACCESS_DENIED(HttpStatus.NOT_FOUND, "e40414", "해당 코스를 삭제할 수 없습니다."),
     INSUFFICIENT_USER_POINTS(HttpStatus.NOT_FOUND, "e40413", "유저의 포인트가 부족합니다."),
     SORT_TYPE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "e40414", "해당 순서 타입을 찾을 수 없습니다."),
     ADVERTISEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "e40415", "해당 광고를 찾을 수 없습니다."),

--- a/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
+++ b/dateroad-domain/src/main/java/org/dateroad/user/domain/User.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.dateroad.common.BaseTimeEntity;
 
+import java.util.Objects;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(access = AccessLevel.PRIVATE)
@@ -52,6 +54,14 @@ public class User extends BaseTimeEntity {
     @NotNull
     @Setter
     private int totalPoint = 0;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || !(o instanceof User)) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.getId());  // Compare using the unique ID
+    }
 
     public static User create(final String name, final String platformUserId, final Platform platForm, final String imageUrl) {
         return User.builder()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#277

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
<img width="648" alt="image" src="https://github.com/user-attachments/assets/f8bc7642-38de-433d-94b2-8e3d6ab07e6d">

위 사진처럼 Course 삭제 시 발생하는 404 에러를 해결했습니다.


다음 코드는 Coures 삭제 시 삭제하는 주체의 User와 Course의 User가 동일한지 검증해주는 기존의 validateCourse 메서드입니다.
```
    private void validateCourse(final User findUser, final Course findCourse) {
        if (!findUser.equals(findCourse.getUser())) {
            throw new ForbiddenException(FailureCode.COURSE_DELETE_ACCESS_DENIED);
        }
    }
```

![image](https://github.com/user-attachments/assets/499c5d16-6dbc-4cca-8df5-1a686c774088)

해당 코드를 디버깅 해본 결과 findCourse의 user와 findUser는 서로 다른 객체를 참조하고 있기 때문에 다른 객체라고 인식되어 발생한 오류입니다.
이는 Course에서 User를 ManyToOne으로 지연로딩하고 있기 때문에, 최초 Course 조회에서 User를 프록시 객체로 가져오고, 프록시 객체는 실제 객체의 상속본 이기 때문에 findUser와 다른 객체라고 인식되었습니다. 따라서 이의 경우 다음과 같은 User에서 equals 메서드 오버라이딩을 통해 문제를 해결할 수 있습니다.

```
@Override
public boolean equals(Object o) {
    if (this == o) return true;
    if (o == null || !(o instanceof User)) return false;
    User user = (User) o;
    return Objects.equals(id, user.id);  // Compare using the unique ID
}
```

참고) 여기서 Object의 User(Course의 User)가 프록시 객체이기 때문에  if (o == null || !(o instanceof User)) return false; 대신   if (o == null || getClass() != o.getClass()) return false;를 구현할 경우 false로 동일한 오류가 반복됩니다.

![image](https://github.com/user-attachments/assets/ca95e996-7344-4264-bc61-24621fdd0941)
하지만 위와 같이 프록시 객체는 id도 null 값으로 설정되어 있어 getter를 사용해 실제 쿼리를 한 번 더 날려서 (coures의)user의 id를 받아와야 했습니다.

```
    @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || !(o instanceof User)) return false;
        User user = (User) o;
        return Objects.equals(id, user.getId());  // Compare using the unique ID
    }
```
따라서 최종적으로 위와 같은 코드로 equals를 재정의 해줬습니다.


![image](https://github.com/user-attachments/assets/dfa56ed8-5afd-4f7f-890f-9d181d2f2125)
참고) 지연로딩으로 인해 getId() 메서드를 통해 쿼리를 한 번 더 날려 받아온다 해서 실제 날아가는 쿼리를 (야매로,,, sout,,,) 확인해본 결과 sout("1111111") 이전까지 course 만 조회하는 쿼리문 1개만 나가고, 여전히 course의 user에 대한 쿼리는 나가지 않는 것으로 확인 되었습니다.

-> 이유: 식별자를 조회할 때는 프록시를 초기화하지 않는다. 프록시 초기화 과정은 프록시 객체 내부의 ByteBuddyInterceptor라는 클래스가, 정확히는 상위의 추상 클래스인 AbstractLazyInitializer가 담당하게 되는데, AbstractLazyInitializer의 getIdentifier 메서드를 호출하고, 이 메서드는 결과적으로 id를 반환해준다. 따라서 결과적으로 AbstractLazyInitializer가 id 값을 가지고 있기 때문에 getId()만 사용했을 경우 추가적인 쿼리가 나가지 않는다. 

(id값은 프록시가 아니라 프록시 내부의 인터셉터에 들어있고, 프록시 객체가 가진 필드값들은 모두 null이다. 일반적으로는 필드로 꺼내 쓰기 때문에 상관 없겠지만, 만약 필드가 public이어서 바로 접근한다면 null에 접근하게 된다.)


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- https://ksh-dev.tistory.com/78
- https://terry9611.tistory.com/368
- https://tecoble.techcourse.co.kr/post/2022-10-17-jpa-hibernate-proxy/

## 📟 관련 이슈
- Resolved: #277 