### PR TITLE
[FEAT] 서버 에러 로그 Discord 연결 - #226

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
+++ b/dateroad-api/src/main/java/org/dateroad/user/service/AuthService.java
@@ -19,7 +19,6 @@ import org.dateroad.image.service.ImageService;
 import org.dateroad.point.repository.PointRepository;
 import org.dateroad.refreshtoken.domain.RefreshToken;
 import org.dateroad.refreshtoken.repository.RefreshTokenRepository;
-import org.dateroad.s3.S3Service;
 import org.dateroad.tag.domain.DateTagType;
 import org.dateroad.tag.domain.UserTag;
 import org.dateroad.tag.repository.UserTagRepository;

--- a/dateroad-api/src/main/resources/console-appender.xml
+++ b/dateroad-api/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/dateroad-api/src/main/resources/discord-appender.xml
+++ b/dateroad-api/src/main/resources/discord-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="DISCORD" class="org.dateroad.feign.discord.DiscordLogAppender">
+        <param name="discordLogUrl" value="${discordLogUrl}" />
+    </appender>
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+    <!-- 비동기 Discord 로그 설정 -->
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+</included>

--- a/dateroad-api/src/main/resources/logback-spring.xml
+++ b/dateroad-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProperty name="discordLogUrl" source="feign.discord.webhook.log-url"/>
+    <include resource="console-appender.xml"/>
+    <include resource="discord-appender.xml"/>
+
+    <!-- 로그 레벨 지정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="ASYNC_DISCORD" />
+    </root>
+</configuration>

--- a/dateroad-api/src/test/java/org/dateroad/user/service/AuthServiceTest.java
+++ b/dateroad-api/src/test/java/org/dateroad/user/service/AuthServiceTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.dateroad.auth.jwt.JwtProvider;
 import org.dateroad.auth.jwt.Token;
 import org.dateroad.code.FailureCode;

--- a/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
+++ b/dateroad-common/src/main/java/org/dateroad/code/FailureCode.java
@@ -58,7 +58,7 @@ public enum FailureCode {
      * 403 Forbidden
      */
     FORBIDDEN(HttpStatus.FORBIDDEN, "e4030", "리소스 접근 권한이 없습니다."),
-    DATE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "e4032", "해당 일정에 권한이 없습니다."),
+    DATE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "e4031", "해당 일정에 권한이 없습니다."),
 
     /**
      * 404 Not Found
@@ -99,8 +99,9 @@ public enum FailureCode {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5000", "서버 내부 오류입니다."),
     COURSE_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"e5001" , "코스 생성에 실패했습니다."),
-    POINT_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5002", "포인트 생성에 실패했습니다"),
-    REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5003", "Redis 연결에 실패했습니다");
+    POINT_CREATE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5002", "포인트 생성에 실패했습니다."),
+    REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5003", "Redis 연결에 실패했습니다."),
+    DISCORD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "e5004", "디스코드 로그 전송 내용이 존재하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/dateroad-common/src/main/java/org/dateroad/event/SignUpEventInfo.java
+++ b/dateroad-common/src/main/java/org/dateroad/event/SignUpEventInfo.java
@@ -1,8 +1,9 @@
 package org.dateroad.event;
+import lombok.AccessLevel;
 import lombok.Builder;
 import org.dateroad.code.EventCode;
 
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public record SignUpEventInfo (
         EventCode eventCode,
         String nickName,

--- a/dateroad-common/src/main/java/org/dateroad/mdc/MDCFilter.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/MDCFilter.java
@@ -1,0 +1,29 @@
+package org.dateroad.mdc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+import java.io.IOException;
+
+@Slf4j
+public class MDCFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        HttpServletRequest httpReq = WebUtils.getNativeRequest(request, HttpServletRequest.class);
+
+        MDCManager.setJsonValue(MDCManager.MDC_REQUEST_URI, MDCManager.getRequestUri(httpReq));
+        MDCManager.setJsonValue(MDCManager.MDC_USER_IP, MDCManager.getUserIP(httpReq));
+        MDCManager.setJsonValue(MDCManager.MDC_REQUEST_COOKIES, MDCManager.getCookies(httpReq));
+        MDCManager.setJsonValue(MDCManager.MDC_REQUEST_ORIGIN, MDCManager.getRequestOrigin(httpReq));
+        MDCManager.setJsonValue(MDCManager.MDC_HEADER, MDCManager.getHeader(httpReq));
+        MDCManager.setJsonValue(MDCManager.MDC_PARAMETER, MDCManager.getParameter(httpReq));
+        MDCManager.set(MDCManager.MDC_BODY, MDCManager.getBody(httpReq));
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/mdc/MDCFilterConfig.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/MDCFilterConfig.java
@@ -1,0 +1,24 @@
+package org.dateroad.mdc;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("!local")
+@Configuration
+public class MDCFilterConfig {
+    @Bean
+    public FilterRegistrationBean<RequestWrappingFilter> secondFilter() {
+        FilterRegistrationBean<RequestWrappingFilter> filterRegistrationBean = new FilterRegistrationBean<>(new RequestWrappingFilter());
+        filterRegistrationBean.setOrder(0);
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<MDCFilter> thirdFilter() {
+        FilterRegistrationBean<MDCFilter> filterRegistrationBean = new FilterRegistrationBean<>(new MDCFilter());
+        filterRegistrationBean.setOrder(1);
+        return filterRegistrationBean;
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/mdc/MDCManager.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/MDCManager.java
@@ -1,0 +1,93 @@
+package org.dateroad.mdc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.slf4j.spi.MDCAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class MDCManager {
+    public static final String MDC_REQUEST_URI = "Request URI";
+    public static final String MDC_USER_IP = "사용자 IP";
+    public static final String MDC_REQUEST_COOKIES = "Request Cookie";
+    public static final String MDC_REQUEST_ORIGIN = "Request Origin";
+    public static final String MDC_HEADER = "HTTP Header";
+    public static final String MDC_PARAMETER = "Parameter";
+    public static final String MDC_BODY = "HTTP Body";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final MDCAdapter mdcAdapter = MDC.getMDCAdapter();
+    public static void set(String key, String value) {
+        mdcAdapter.put(key, value);
+    }
+
+    public static Object get(String key) {
+        return mdcAdapter.get(key);
+    }
+
+    public static void setJsonValue(String key, Object value) throws JsonProcessingException {
+        try {
+            if (value != null) {
+                String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+                mdcAdapter.put(key, json);
+            } else {
+                mdcAdapter.put(key, "내용이 없습니다.");
+            }
+        } catch (JsonProcessingException ex) {
+            throw ex;
+        }
+    }
+
+    public static String getUserIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null)
+            ip = request.getRemoteAddr();
+
+        return ip;
+    }
+
+    public static Cookie[] getCookies(HttpServletRequest request) {
+        return request.getCookies();
+    }
+
+    public static String getRequestOrigin(HttpServletRequest request) {
+        return request.getHeader("Origin");
+    }
+
+    public static Map<String, String> getHeader(HttpServletRequest request) {
+        Map<String, String> headerMap = new HashMap<>();
+        request.getHeaderNames().asIterator()
+                .forEachRemaining(name -> {
+                    if (!name.equals("user-agent")) {
+                        headerMap.put(name, request.getHeader(name));
+                    }
+                });
+        return headerMap;
+    }
+
+    public static Map<String, String> getParameter(HttpServletRequest request) {
+        Map<String, String> paramMap = new HashMap<>();
+        request.getParameterNames().asIterator()
+                .forEachRemaining(name -> paramMap.put(name, request.getParameter(name)));
+
+        return paramMap;
+    }
+
+    public static String getBody(HttpServletRequest request) {
+        RequestBodyWrapper requestBodyWrapper = WebUtils.getNativeRequest(request, RequestBodyWrapper.class);
+
+        if (requestBodyWrapper != null) {
+            return requestBodyWrapper.getRequestBody();
+        }
+
+        return "requestBody 정보 없음";
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/mdc/MDCManager.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/MDCManager.java
@@ -46,6 +46,10 @@ public class MDCManager {
         }
     }
 
+    public static String getRequestUri(HttpServletRequest request) {
+        return request.getRequestURI();
+    }
+
     public static String getUserIP(HttpServletRequest request) {
         String ip = request.getHeader("X-Forwarded-For");
         if (ip == null)

--- a/dateroad-common/src/main/java/org/dateroad/mdc/RequestBodyWrapper.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/RequestBodyWrapper.java
@@ -1,0 +1,66 @@
+package org.dateroad.mdc;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.Getter;
+import org.dateroad.code.FailureCode;
+import org.dateroad.exception.BadRequestException;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@Getter
+public class RequestBodyWrapper extends HttpServletRequestWrapper {
+    private final String requestBody;
+
+    public RequestBodyWrapper(HttpServletRequest request) {
+        super(request);
+
+        StringBuilder stringBuilder = new StringBuilder();
+        try (BufferedReader bufferedReader = request.getReader()) {
+            char[] charBuffer = new char[128];
+            int bytesRead;
+            while ((bytesRead = bufferedReader.read(charBuffer)) > 0) {
+                stringBuilder.append(charBuffer, 0, bytesRead);
+            }
+        } catch (IOException e) {
+            throw new BadRequestException(FailureCode.BAD_REQUEST);
+        }
+
+        requestBody = stringBuilder.toString();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(requestBody.getBytes());
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                throw new UnsupportedOperationException();
+            }
+
+            public int read() {
+                return byteArrayInputStream.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(this.getInputStream()));
+    }
+}

--- a/dateroad-common/src/main/java/org/dateroad/mdc/RequestWrappingFilter.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/RequestWrappingFilter.java
@@ -1,0 +1,19 @@
+package org.dateroad.mdc;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class RequestWrappingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        RequestBodyWrapper requestBodyWrapper = new RequestBodyWrapper(request);
+        filterChain.doFilter(requestBodyWrapper, response);
+    }
+}

--- a/dateroad-external/src/main/java/org/dateroad/feign/discord/DiscordLogAppender.java
+++ b/dateroad-external/src/main/java/org/dateroad/feign/discord/DiscordLogAppender.java
@@ -1,0 +1,103 @@
+package org.dateroad.feign.discord;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.AppenderBase;
+import io.micrometer.core.instrument.util.StringEscapeUtils;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.dateroad.mdc.MDCManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Profile("!local")
+@Component
+@Setter
+public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
+    private String discordLogUrl;
+
+    @Override
+    public void start() {
+        if (discordLogUrl == null || discordLogUrl.isEmpty() ) {
+            addError("Discord is not configured properly. Please set the discordLogUrl");
+            return;
+        }
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        Map<String, String> mdcPropertyMap = eventObject.getMDCPropertyMap();
+
+        String level = eventObject.getLevel().levelStr;
+        String exceptionBrief = "";
+        String exceptionDetail = "";
+        IThrowableProxy throwable = eventObject.getThrowableProxy();
+
+        if (throwable != null) {
+            exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+        }
+
+        if (exceptionBrief.equals("")) {
+            exceptionBrief = "EXCEPTION 정보가 남지 않았습니다.";
+        }
+
+        StringBuilder logMessage = new StringBuilder();
+
+        appendWithNewLine(logMessage, "[" + level + " - 문제 간략 내용] " + exceptionBrief);
+        appendWithNewLine(logMessage,  "[Time] " +  LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_REQUEST_URI + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_REQUEST_URI)));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_USER_IP + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_USER_IP)));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_HEADER + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_HEADER).replaceAll("[\\{\\{\\}]", "")));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_REQUEST_COOKIES + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_REQUEST_COOKIES).replaceAll("[\\{\\{\\}]", "")));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_PARAMETER + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_PARAMETER).replaceAll("[\\{\\{\\}]", "")));
+        appendWithNewLine(logMessage, "[" + MDCManager.MDC_BODY + "] " + StringEscapeUtils.escapeJson(mdcPropertyMap.get(MDCManager.MDC_BODY)));
+
+        sendToDiscord(logMessage.toString());
+
+        if (throwable != null) {
+            exceptionDetail = ThrowableProxyUtil.asString(throwable);
+            String exception = "[Exception 상세 내용] " + exceptionDetail.substring(0, 1000);
+            sendToDiscord(exception);
+        }
+    }
+
+    private void appendWithNewLine(StringBuilder sb, String text) {
+        sb.append(text).append("\n");
+    }
+
+    private void sendToDiscord(String logMessage) {
+        if (logMessage.length() > 2000) {
+            logMessage = logMessage.substring(0, 1950) + "......";
+        }
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Map<String, String> payload = new HashMap<>();
+        payload.put("content", logMessage);
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(discordLogUrl, request, String.class);
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                addError("Failed to send log message to Discord: " + response.getStatusCode());
+            }
+        } catch (Exception e) {
+            log.error("Exception occurred while sending log message to Discord", e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#226

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
서버 에러 로그를 Discord에 연동했습니다.

우선 로깅 시스템에서 로그 레코드에 정보를 추가로 입력하여 로그를 더욱 의미있고 편히 사용할 수 있게 해주며, 쓰레드 로컬을 사용해 쓰레드마다 고유의 값을 저장할 수 있기 때문에 멀티쓰레드 환경에서 편리한 MDC를 활용해서 Filter를 구현했습니다.

또한, Requst -> 필터 -> 디스패처 서블릿 -> 인터셉터 -> 컨트롤러 값 의 과정에서 Interceptor에서 getInputStream() 을 호출하여 Http Body를 읽으면서 소비하였기 때문에
Controller의 Http Body가 비어있기 때문에 한 번 읽고 사라지는 HttpBody가 아닌 getInputStream()에서 요청 Http Body를 복사하여 값을 저장하고 반환하는 RequestBodyWrapper를 구현하고, 이를 RequestWrappingFilter를 통해 필터를 등록해줬습니다.

이때, 어떤 에러든 정보를 받기 위해서는 구현한 RequestWrappingFilter, MDCFilter를 필터가 맨 앞단에 있어야 한다 생각되어 순서에 0,1번째로 등록해주고, 로컬이 아닌 환경에서만 실행될 수 있도록  MDCFilterConfig를 통해 구현했습니다. 또한, 서블릿에서 다른 서블릿으로 dispatch될 경우 동일한 Filter가 여러 번 거치는 것을 막기 위해 Filter를 상속받는 것이 아닌 OncePerRequestFilter를 상속받아서 구현했습니다.

Logback에서 Appender를 추가해주기 위해서 AppenderBase<ILoggingEvent>를 상속받아 DiscordLogAppender를 구현해줬습니다. (Logback 프레임워크에서 로그 이벤트를 특정 대상으로 보내는 기능을 구현할 수 있는 기본 클래스인 AppenderBase와 Logback에서 발생한 로그 이벤트를 표현하는 인터페이스이며, 로그 메시지, 로그 레벨(예: INFO, ERROR), 스레드 정보, MDC 값, 예외 스택 트레이스 등 로그와 관련된 모든 정보를 담고 있는 객체인 ILoggingEvent를 활용해주기 위함입니다.)
Discord 웹후크 주소에 POST메서드를 통해 "content"로 로그 메세지를 전송해줬으며 2000자 이상은 전송이 되지 않기 때문에 2000자를 식별하는 로직도 추가로 구했습니다.
따라서, 최종적으로 User의 정보와 Exception 상세 내용을 두번 전송할 수 있도록 구현했습니다.

Logback기능을 활용하기 위해 logback-spring.xml을 설정해서 DiscordAppender을 연동해줬습니다.

![image](https://github.com/user-attachments/assets/22710aa8-20b9-4c22-9d41-53e227ccb28b)


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
MDC Filter
- https://velog.io/@no-int/JAVAMDC-Filter-%EB%A1%9C%EA%B7%B8-%EA%B4%80%EB%A6%AC
HttpServletRequestWrapper 
- https://velog.io/@best1370/HttpRequest%EC%97%90%EC%84%9C-body%EA%B0%92-%EA%B0%80%EC%A0%B8%EC%98%A4%EA%B8%B0
OncePerRequestFilter
- https://minkukjo.github.io/framework/2020/12/18/Spring-142/
- https://velog.io/@jmjmjmz732002/Springboot-OncePerRequestFilter-vs-GenericFilterBean
Logback
- https://velog.io/@gehwan96/logback-%EC%84%A4%EC%A0%95
- https://velog.io/@kshired/Logback%EC%9C%BC%EB%A1%9C-Slack-message-%EB%B3%B4%EB%82%B4%EA%B8%B0
- https://velog.io/@woosim34/Springboot-Logback-%EC%84%A4%EC%A0%95%ED%95%B4%EB%B3%B4%EA%B8%B0
- https://wbluke.tistory.com/51
- https://velog.io/@smc9919/SpringBoot-Discord-%EC%95%8C%EB%A6%BC-%EC%97%B0%EB%8F%99Logback


## 📟 관련 이슈
- Resolved: #226