### PR TITLE
[FIX] Multipart 요청 시 Filter 오류 해결 - #296

### DIFF
--- a/dateroad-common/src/main/java/org/dateroad/mdc/RequestBodyWrapper.java
+++ b/dateroad-common/src/main/java/org/dateroad/mdc/RequestBodyWrapper.java
@@ -20,6 +20,11 @@ public class RequestBodyWrapper extends HttpServletRequestWrapper {
     public RequestBodyWrapper(HttpServletRequest request) {
         super(request);
 
+        if (request.getContentType() != null && request.getContentType().startsWith("multipart/")) {
+            requestBody = "Multipart 요청, 본문을 기록하지 않음";
+            return;
+        }
+
         StringBuilder stringBuilder = new StringBuilder();
         try (BufferedReader bufferedReader = request.getReader()) {
             char[] charBuffer = new char[128];


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#296

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
기존 코드에서 에러 로깅을 위해 있는 RequestBodyWrapper 클래스가 요청 본문을 읽을 때, 모든 요청에 대해 getReader()를 사용하여 본문을 문자열로 처리하고 있었습니다. 그러나 Multipart 요청의 경우, 파일 데이터와 텍스트 데이터가 함께 전송되는 바이너리 데이터 구조를 가지고 있습니다. 이를 일반 텍스트로 처리하려고 시도하면서 IOException이 발생했습니다.
즉, Multipart 요청의 본문은 파일 업로드나 기타 바이너리 데이터를 포함할 수 있기 때문에, BufferedReader로 읽으려는 시도가 실패하여 예외가 발생한 것입니다.

따라서, Content-Type을 확인하여 요청이 multipart/로 시작하는 경우, 본문을 읽지 않고 "Multipart 요청, 본문을 기록하지 않음"이라는 메시지를 설정하여 Multipart 요청에서 본문을 처리하려고 시도하는 부분을 건너뛰도록 수정하여 예외가 발생하지 않도록 해당 오류를 해결했습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #296 