### PR TITLE
[FIX] 캐시로 인한 User TotalPoint 에러 해결 - #346

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/point/api/PointApi.java
+++ b/dateroad-api/src/main/java/org/dateroad/point/api/PointApi.java
@@ -85,4 +85,9 @@ public interface PointApi {
             @Parameter(hidden = true)
             @UserId Long userId
     );
+
+    public ResponseEntity<Void> awardAdsPoints(
+            @Parameter(hidden = true)
+            @UserId Long userId
+    );
 }

--- a/dateroad-api/src/main/java/org/dateroad/point/service/PointService.java
+++ b/dateroad-api/src/main/java/org/dateroad/point/service/PointService.java
@@ -2,8 +2,6 @@ package org.dateroad.point.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.dateroad.code.FailureCode;
-import org.dateroad.exception.EntityNotFoundException;
 import org.dateroad.point.domain.Point;
 import org.dateroad.point.domain.TransactionType;
 import org.dateroad.point.dto.response.PointGetAllRes;
@@ -12,7 +10,7 @@ import org.dateroad.point.dto.response.PointGetAllRes.PointsDto;
 import org.dateroad.point.dto.response.PointDto;
 import org.dateroad.point.repository.PointRepository;
 import org.dateroad.user.domain.User;
-import org.dateroad.user.repository.UserRepository;
+import org.dateroad.user.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PointService {
     private final PointRepository pointRepository;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
     private static final int ADS_POINT = 50;
     private static final String ADS_DESCRIPTION = "광고 시청";
@@ -36,9 +34,9 @@ public class PointService {
 
     @Transactional
     public void awardAdsPoints(final Long userId) {
-        User user = getUser(userId);
+        User user = userService.getUser(userId);
         user.setTotalPoint(user.getTotalPoint() + ADS_POINT);
-        userRepository.save(user);
+        userService.saveUser(user);
         pointRepository.save(Point.create(user, ADS_POINT, TransactionType.POINT_GAINED, ADS_DESCRIPTION));
     }
 
@@ -47,10 +45,5 @@ public class PointService {
                 .filter(point -> point.transactionType() == type)
                 .map(PointDtoRes::of)
                 .toList());
-    }
-
-    private User getUser(final Long userId) {
-        return userRepository.findUserById(userId)
-                .orElseThrow(() -> new EntityNotFoundException(FailureCode.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#346

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 광고 시청 후 포인트 적립 API에서 User의 totalPoint가 제대로 누적되지 않는 문제를 해결했습니다.
- 원인은 기존에 User를 업데이트할 때 캐시에 저장된 초기 값(ex. 0)이 반환되어 매번 50 포인트만 적용되는 현상이었습니다.
- 이를 해결하기 위해, 기존에 @CachePut을 적용하여 DB에 저장과 동시에 캐시에도 업데이트된 User 정보를 반영하도록 만들어진 UserService의 saveUser 메서드를 활용하는 방식으로 수정했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 캐시가 업데이트되지 않으면, getUser() 호출 시 항상 최초 캐시된 User 값이 반환되어 누적된 포인트가 반영되지 않습니다.
- 수정 후, awardAdsPoints 메서드는 userService.getUser()로 조회한 후, setTotalPoint()로 포인트를 더하고 userService.saveUser()를 통해 캐시와 DB에 최신 상태를 반영합니다.

## 📟 관련 이슈
- Resolved: #346