### PR TITLE
[FEAT] Place Field 추가 및 Course 생성, 세부 조회 API 구현

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseControllerV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseControllerV2.java
@@ -1,0 +1,57 @@
+package org.dateroad.course.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.dateroad.auth.argumentresolve.UserId;
+import org.dateroad.code.FailureCode;
+import org.dateroad.course.dto.request.CourseCreateReq;
+import org.dateroad.course.dto.request.CoursePlaceGetReqV2;
+import org.dateroad.course.dto.request.TagCreateReq;
+import org.dateroad.course.dto.response.CourseCreateRes;
+import org.dateroad.course.service.CourseService;
+import org.dateroad.date.dto.response.CourseGetDetailResV2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.dateroad.common.ValidatorUtil.validateListSizeMax;
+import static org.dateroad.common.ValidatorUtil.validateListSizeMin;
+
+@RestController
+@RequestMapping("/api/v2/courses")
+@RequiredArgsConstructor
+public class CourseControllerV2 {
+    private final CourseService courseService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE,
+            MediaType.APPLICATION_OCTET_STREAM_VALUE}, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CourseCreateRes> createCourse(
+            @UserId final Long userId,
+            @RequestPart("course") @Valid final CourseCreateReq courseCreateReq,
+            @RequestPart("tags") @Validated @Size(min = 1, max = 3) final List<TagCreateReq> tags,
+            @RequestPart("places") @Validated @Size(min = 1) final List<CoursePlaceGetReqV2> places,
+            @RequestPart("images") @Validated @Size(min =1, max = 10) final List<MultipartFile> images
+    ) throws ExecutionException, InterruptedException {
+        validateListSizeMin(places, 1, FailureCode.WRONG_COURSE_PLACE_SIZE);
+        validateListSizeMin(tags, 1, FailureCode.WRONG_TAG_SIZE);
+        validateListSizeMax(tags, 3, FailureCode.WRONG_TAG_SIZE);
+        validateListSizeMax(images, 10, FailureCode.WRONG_IMAGE_LIST_SIZE);
+        CourseCreateRes courseCreateRes = courseService.createCourseV2(userId, courseCreateReq, places, images, tags);
+        return ResponseEntity.status(HttpStatus.CREATED).body(courseCreateRes);
+    }
+
+    @GetMapping("/{courseId}")
+    public ResponseEntity<CourseGetDetailResV2> getCourseDetail(@UserId Long userId,
+                                                              @PathVariable("courseId") Long courseId) {
+        CourseGetDetailResV2 courseGetDetailRes = courseService.getCourseDetailV2(userId, courseId);
+        return ResponseEntity.ok(courseGetDetailRes);
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateEventV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateEventV2.java
@@ -1,0 +1,29 @@
+package org.dateroad.course.dto.request;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.dateroad.date.domain.Course;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CourseCreateEventV2{
+    private Course course;
+    private List<CoursePlaceGetReqV2> places;
+    private List<TagCreateReq> tags;
+
+    public static CourseCreateEventV2 of(Course course,
+                                       List<CoursePlaceGetReqV2> places,
+                                       List<TagCreateReq> tags) {
+        return CourseCreateEventV2.builder()
+                .course(course)
+                .places(places)
+                .tags(tags)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CoursePlaceGetReqV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CoursePlaceGetReqV2.java
@@ -1,0 +1,29 @@
+package org.dateroad.course.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CoursePlaceGetReqV2 {
+    private String title;
+    private float duration;
+    private int sequence;
+    private String address;
+
+    public static CoursePlaceGetReqV2 of(final String title, final float duration, final int sequence, final String address) {
+        return CoursePlaceGetReqV2.builder()
+                .title(title)
+                .duration(duration)
+                .sequence(sequence)
+                .address(address)
+                .build();
+    }
+}

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CoursePlaceGetReqV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CoursePlaceGetReqV2.java
@@ -3,10 +3,8 @@ package org.dateroad.course.dto.request;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CoursePlaceService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CoursePlaceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.dateroad.course.dto.request.CoursePlaceGetReq;
+import org.dateroad.course.dto.request.CoursePlaceGetReqV2;
 import org.dateroad.date.domain.Course;
 import org.dateroad.place.domain.CoursePlace;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,18 @@ public class CoursePlaceService {
                         placeReq.getDuration(),
                         course,
                         placeReq.getSequence()
+                ))
+                .toList();
+    }
+
+    public List<CoursePlace> createCoursePlaceV2(final List<CoursePlaceGetReqV2> places, final Course course) {
+        return places.stream()
+                .map(placeReq -> CoursePlace.createV2(
+                        placeReq.getTitle(),
+                        placeReq.getDuration(),
+                        course,
+                        placeReq.getSequence(),
+                        placeReq.getAddress()
                 ))
                 .toList();
     }

--- a/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/service/CourseService.java
@@ -12,12 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.dateroad.code.FailureCode;
 import org.dateroad.common.Constants;
 import org.dateroad.course.dto.CourseWithPlacesAndTagsDto;
-import org.dateroad.course.dto.request.CourseCreateEvent;
-import org.dateroad.course.dto.request.CourseCreateReq;
-import org.dateroad.course.dto.request.CourseGetAllReq;
-import org.dateroad.course.dto.request.CoursePlaceGetReq;
-import org.dateroad.course.dto.request.PointUseReq;
-import org.dateroad.course.dto.request.TagCreateReq;
+import org.dateroad.course.dto.request.*;
 import org.dateroad.course.dto.response.CourseAccessGetAllRes;
 import org.dateroad.course.dto.response.CourseCreateRes;
 import org.dateroad.course.dto.response.CourseDtoGetRes;
@@ -25,6 +20,7 @@ import org.dateroad.course.dto.response.CourseGetAllRes;
 import org.dateroad.course.dto.response.DateAccessCreateRes;
 import org.dateroad.date.domain.Course;
 import org.dateroad.date.dto.response.CourseGetDetailRes;
+import org.dateroad.date.dto.response.CourseGetDetailResV2;
 import org.dateroad.date.repository.CourseRepository;
 import org.dateroad.dateAccess.domain.DateAccess;
 import org.dateroad.dateAccess.repository.DateAccessRepository;
@@ -215,6 +211,39 @@ public class CourseService {
     }
 
     @Transactional
+    @CacheEvict(value = "courses", allEntries = true)
+    public CourseCreateRes createCourseV2(final Long userId, final CourseCreateReq courseRegisterReq,
+                                          final List<CoursePlaceGetReqV2> places, final List<MultipartFile> images,
+                                          List<TagCreateReq> tags) throws ExecutionException, InterruptedException {
+        final float totalTime = places.stream()
+                .map(CoursePlaceGetReqV2::getDuration)
+                .reduce(0.0f, Float::sum);
+        User user = getUser(userId);
+        Course course = Course.create(
+                user,
+                courseRegisterReq.getTitle(),
+                courseRegisterReq.getDescription(),
+                courseRegisterReq.getCountry(),
+                courseRegisterReq.getCity(),
+                courseRegisterReq.getCost(),
+                courseRegisterReq.getDate(),
+                courseRegisterReq.getStartAt(),
+                totalTime
+        );
+        Course newcourse = courseRepository.save(course);
+        CourseWithPlacesAndTagsDto courseWithPlacesAndTagsDto = asyncService.runAsyncTasksV2(CourseCreateEventV2.of(newcourse, places, tags));
+        String thumbnail = asyncService.createCourseImages(images, newcourse);
+        course.setThumbnail(thumbnail);
+        courseRepository.save(newcourse);
+        coursePlaceRepository.saveAll(courseWithPlacesAndTagsDto.coursePlaces());
+        courseTagRepository.saveAll(courseWithPlacesAndTagsDto.courseTags());
+        RecordId recordId = asyncService.publishEvenUserPoint(userId, PointUseReq.of(Constants.COURSE_CREATE_POINT, TransactionType.POINT_GAINED, "코스 등록하기"));
+        Long userCourseCount = courseRepository.countByUser(user);
+        courseRollbackService.rollbackCourse(recordId);
+        return CourseCreateRes.of(newcourse.getId(), user.getTotalPoint() + Constants.COURSE_CREATE_POINT, userCourseCount);
+    }
+
+    @Transactional
     public DateAccessCreateRes openCourse(final Long userId, final Long courseId, final PointUseReq pointUseReq) {
         Course course = getCourse(courseId);
         User user = getUser(userId);
@@ -309,6 +338,66 @@ public class CourseService {
                 isUserLiked
         );
     }
+
+    public CourseGetDetailResV2 getCourseDetailV2(final Long userId, final Long courseId) {
+        Course foundCourse = findCourseById(courseId);
+        User foundUser = findUserById(userId);
+        List<Image> foundImages = imageRepository.findAllByCourseId(foundCourse.getId());
+        validateImage(foundImages);
+
+        List<CourseGetDetailResV2.ImagesList> images = foundImages.stream()
+                .map(imageList -> CourseGetDetailResV2.ImagesList.of(
+                        imageList.getImageUrl(),
+                        imageList.getSequence())
+                ).toList();
+
+        List<CoursePlace> foundCoursePlaces = coursePlaceRepository.findAllCoursePlacesByCourseId(foundCourse.getId(), Sort.by(Sort.Direction.ASC, "sequence"));
+        validateCoursePlace(foundCoursePlaces);
+
+        List<CourseGetDetailResV2.Places> places = foundCoursePlaces.stream()
+                .map(placesList -> CourseGetDetailResV2.Places.of(
+                        placesList.getSequence(),
+                        placesList.getName(),
+                        placesList.getDuration(),
+                        placesList.getAddress())
+                ).toList();
+
+        List<CourseTag> foundTags = courseTagRepository.findAllCourseTagByCourseId(foundCourse.getId());
+        validateCourseTag(foundTags);
+
+        List<CourseGetDetailResV2.CourseTag> tags = foundTags.stream()
+                .map(tagList -> CourseGetDetailResV2.CourseTag.of(
+                        tagList.getDateTagType())
+                ).toList();
+
+        int likesCount = likeRepository.countByCourse(foundCourse);
+
+        boolean isCourseMine = courseRepository.existsCourseByUserAndId(foundUser, courseId);
+
+        boolean isUserLiked = false;
+
+        boolean isAccess = dateAccessRepository.existsDateAccessByUserIdAndCourseId(foundUser.getId(),
+                foundCourse.getId());
+
+        if (!isCourseMine) {
+            isUserLiked = likeRepository.existsLikeByUserIdAndCourseId(foundUser.getId(), foundCourse.getId());
+        } else {
+            isAccess = true;
+        }
+
+        return CourseGetDetailResV2.of(
+                foundCourse,
+                images,
+                likesCount,
+                places,
+                tags,
+                isAccess,
+                foundUser,
+                isCourseMine,
+                isUserLiked
+        );
+    }
+
 
     private User findUserById(final Long userId) {
         return userRepository.findById(userId).orElseThrow(

--- a/dateroad-api/src/main/java/org/dateroad/date/dto/response/CourseGetDetailResV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/date/dto/response/CourseGetDetailResV2.java
@@ -1,0 +1,107 @@
+package org.dateroad.date.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.dateroad.date.domain.Course;
+import org.dateroad.date.domain.Region;
+import org.dateroad.tag.domain.DateTagType;
+import org.dateroad.user.domain.User;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record CourseGetDetailResV2(
+        Long courseId,
+        List<ImagesList> images,
+        int like,
+        float totalTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+        LocalDate date,
+        Region.SubRegion city,
+        String title,
+        String description,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "hh:mm a", timezone = "Asia/Seoul",locale = "en")
+        LocalTime startAt,
+        List<Places> places,
+        int totalCost,
+        List<CourseTag> tags,
+        boolean isAccess,
+        int free,
+        int totalPoint,
+        boolean isCourseMine,
+        boolean isUserLiked
+) {
+
+    public static CourseGetDetailResV2 of(Course course,
+                                        List<ImagesList> images,
+                                        int like,
+                                        List<Places> places,
+                                        List<CourseTag> tags,
+                                        boolean isAccess,
+                                        User user,
+                                        boolean isCourseMine,
+                                        boolean isUserLiked) {
+        return CourseGetDetailResV2.builder()
+                .courseId(course.getId())
+                .images(images)
+                .like(like)
+                .totalTime(course.getTime())
+                .date(course.getDate())
+                .city(course.getCity())
+                .title(course.getTitle())
+                .description(course.getDescription())
+                .startAt(course.getStartAt())
+                .places(places)
+                .totalCost(course.getCost())
+                .tags(tags)
+                .isAccess(isAccess)
+                .free(user.getFree())
+                .totalPoint(user.getTotalPoint())
+                .isCourseMine(isCourseMine)
+                .isUserLiked(isUserLiked)
+                .build();
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record ImagesList(
+            String imageUrl,
+            int sequence
+    ) {
+        public static ImagesList of(final String imageUrl, final int sequence) {
+            return ImagesList.builder()
+                    .imageUrl(imageUrl)
+                    .sequence(sequence)
+                    .build();
+        }
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record Places(
+            int sequence,
+            String title,
+            float duration,
+            String address
+    ) {
+        public static Places of(final int sequence, final String title, final float duration, final String address) {
+            return Places.builder()
+                    .sequence(sequence)
+                    .title(title)
+                    .duration(duration)
+                    .address(address)
+                    .build();
+        }
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public record CourseTag(
+            DateTagType tag
+    ) {
+        public static CourseTag of(final DateTagType tag) {
+            return CourseTag.builder()
+                    .tag(tag)
+                    .build();
+        }
+    }
+}

--- a/dateroad-domain/src/main/java/org/dateroad/place/domain/CoursePlace.java
+++ b/dateroad-domain/src/main/java/org/dateroad/place/domain/CoursePlace.java
@@ -32,4 +32,14 @@ public class CoursePlace extends Place {
                 .sequence(sequence)
                 .build();
     }
+
+    public static CoursePlace createV2(final String name, float duration, final Course course, final int sequence, final String address) {
+        return CoursePlace.builder()
+                .name(name)
+                .duration(duration)
+                .course(course)
+                .sequence(sequence)
+                .address(address)
+                .build();
+    }
 }

--- a/dateroad-domain/src/main/java/org/dateroad/place/domain/Place.java
+++ b/dateroad-domain/src/main/java/org/dateroad/place/domain/Place.java
@@ -28,6 +28,9 @@ public abstract class Place extends BaseTimeEntity {
     @NotNull
     private String name;
 
+    @Column(name = "address")
+    private String address;
+
     @Column(name = "duration")
     @NotNull
     private float duration;
@@ -35,5 +38,4 @@ public abstract class Place extends BaseTimeEntity {
     @Column(name = "sequence")
     @NotNull
     private int sequence;
-
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#344

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
Date, Course의 Place에 address 필드를 추가했습니다.
더불어 추가적으로 변경된 스펙에 맞게 Course 세부 조회, 생성하는 API Version2를 구현했습니다. (DTO도 함께 새로 만들어줬습니다.)

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #344 