### PR TITLE
[FEAT] Course 생성 API 스펙 변경 - #352

### DIFF
--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseApiV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseApiV2.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import org.dateroad.auth.argumentresolve.UserId;
-import org.dateroad.course.dto.request.CourseCreateReq;
-import org.dateroad.course.dto.request.CourseCreateSwaggerDto;
-import org.dateroad.course.dto.request.CoursePlaceGetReqV2;
-import org.dateroad.course.dto.request.TagCreateReq;
+import org.dateroad.course.dto.request.*;
 import org.dateroad.course.dto.response.CourseCreateRes;
 import org.dateroad.date.dto.response.CourseGetDetailResV2;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +37,7 @@ public interface CourseApiV2 {
     )
     ResponseEntity<CourseCreateRes> createCourse(
             @UserId final Long userId,
-            @RequestPart("course") @Valid final CourseCreateReq courseCreateReq,
+            @RequestPart("course") @Valid final CourseCreateReqV2 courseCreateReq,
             @RequestPart("tags") @Validated @Size(min = 1, max = 3) final List<TagCreateReq> tags,
             @RequestPart("places") @Validated @Size(min = 1) final List<CoursePlaceGetReqV2> places,
             @RequestPart("images") @Validated @Size(min =1, max = 10) final List<MultipartFile> images

--- a/dateroad-api/src/main/java/org/dateroad/course/api/CourseControllerV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/api/CourseControllerV2.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.dateroad.auth.argumentresolve.UserId;
 import org.dateroad.code.FailureCode;
-import org.dateroad.course.dto.request.CourseCreateReq;
+import org.dateroad.course.dto.request.CourseCreateReqV2;
 import org.dateroad.course.dto.request.CoursePlaceGetReqV2;
 import org.dateroad.course.dto.request.TagCreateReq;
 import org.dateroad.course.dto.response.CourseCreateRes;
@@ -35,7 +35,7 @@ public class CourseControllerV2 implements CourseApiV2 {
             MediaType.APPLICATION_OCTET_STREAM_VALUE}, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CourseCreateRes> createCourse(
             @UserId final Long userId,
-            @RequestPart("course") @Valid final CourseCreateReq courseCreateReq,
+            @RequestPart("course") @Valid final CourseCreateReqV2 courseCreateReq,
             @RequestPart("tags") @Validated @Size(min = 1, max = 3) final List<TagCreateReq> tags,
             @RequestPart("places") @Validated @Size(min = 1) final List<CoursePlaceGetReqV2> places,
             @RequestPart("images") @Validated @Size(min =1, max = 10) final List<MultipartFile> images

--- a/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateReqV2.java
+++ b/dateroad-api/src/main/java/org/dateroad/course/dto/request/CourseCreateReqV2.java
@@ -16,7 +16,7 @@ import java.time.LocalTime;
 @Builder(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class CourseCreateReq {
+public class CourseCreateReqV2 {
     @Size(min = 5)
     private String title;
 
@@ -41,10 +41,12 @@ public class CourseCreateReq {
     @Min(0)
     private int cost;
 
-    public static CourseCreateReq of(final String title, final LocalDate date, final LocalTime startAt,
+    private int thumbnailIndex;
+
+    public static CourseCreateReqV2 of(final String title, final LocalDate date, final LocalTime startAt,
                                      final Region.MainRegion country, final Region.SubRegion city,
-                                     final String description, final int cost) {
-        return CourseCreateReq.builder()
+                                     final String description, final int cost, final int thumbnailIndex) {
+        return CourseCreateReqV2.builder()
                 .title(title)
                 .date(date)
                 .startAt(startAt)
@@ -52,6 +54,7 @@ public class CourseCreateReq {
                 .city(city)
                 .description(description)
                 .cost(cost)
+                .thumbnailIndex(thumbnailIndex)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#352

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->

기존에 Course 생성 시 Image로 들어오는 리스트 중 가장 처음꺼를 thumbnail로 저장했습니다. 하지만 따로 thumbnail을 지정할 수 있도록 기능이 추가 되었고, 따라서 Course 생성 시 Req 스펙 변경했습니다. (thumbnailIndex 필드 추가)

받아온 thumbnailIndex을 활용해서 실제 저장되는 Image에서 thumbnail을 지정해주는 비즈니스 로직을 구현하였습니다.
또한, thumbnailIndex가 0보다 작거나 Image List의 size()보다 작을 경우, 이전과 동일하게 가장 먼저 들어온 이미지를 썸네일로 저장하도록 검증하는 로직을 추가했습니다. (예외를 던질 경우, 코스 등록을 다시해야해서 번거로워질 수 있음을 방지)


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈
- Resolved: #352